### PR TITLE
refactor: consolidate directive config interfaces into shared types (Phase 1 of #12)

### DIFF
--- a/src/lib/directives/multi/nguard-different.directive.spec.ts
+++ b/src/lib/directives/multi/nguard-different.directive.spec.ts
@@ -23,77 +23,77 @@ describe('NguardDifferentDirective', () => {
 
     it('should validate two fields with different values, same types (strict disabled / not given)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'def');
-        directive.config = { compareFieldKey: '' };
+        directive.config = { fieldKey: '' };
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate two fields with different values, same types (strict disabled / given)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'def');
-        directive.config = { compareFieldKey: '', isStrict: false };
+        directive.config = { fieldKey: '', isStrict: false };
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate two fields with different values, same types (strict enabled / given)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'def');
-        directive.config = { compareFieldKey: '', isStrict: true };
+        directive.config = { fieldKey: '', isStrict: true };
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate two fields with different values, different types (strict disabled / not given)', () => {
         control = createAbstractControlSpyWithSibling('1', 0);
-        directive.config = { compareFieldKey: '' };
+        directive.config = { fieldKey: '' };
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate two fields with different values, different types (strict disabled / given)', () => {
         control = createAbstractControlSpyWithSibling('1', 0);
-        directive.config = { compareFieldKey: '', isStrict: false };
+        directive.config = { fieldKey: '', isStrict: false };
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate two fields with different values, different types (strict enabled / given)', () => {
         control = createAbstractControlSpyWithSibling('1', 0);
-        directive.config = { compareFieldKey: '', isStrict: true };
+        directive.config = { fieldKey: '', isStrict: true };
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should fail if two fields have the same values (strict enabled / given)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'abc');
-        directive.config = { compareFieldKey: '', isStrict: true };
+        directive.config = { fieldKey: '', isStrict: true };
 
         expect(directive.validate(control)).toEqual({ different: true });
     });
 
     it('should fail if two fields have the same values (strict disabled / given)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'abc');
-        directive.config = { compareFieldKey: '', isStrict: false };
+        directive.config = { fieldKey: '', isStrict: false };
 
         expect(directive.validate(control)).toEqual({ different: true });
     });
 
     it('should fail if two fields have the same values (strict disabled / not given)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'abc');
-        directive.config = { compareFieldKey: '' };
+        directive.config = { fieldKey: '' };
 
         expect(directive.validate(control)).toEqual({ different: true });
     });
 
     it('should fail if two fields have the same values but different types (strict disabled / not given)', () => {
         control = createAbstractControlSpyWithSibling('1', 1);
-        directive.config = { compareFieldKey: '' };
+        directive.config = { fieldKey: '' };
 
         expect(directive.validate(control)).toEqual({ different: true });
     });
 
     it('should fail if two fields have the same values but different types (strict disabled / given)', () => {
         control = createAbstractControlSpyWithSibling('1', 1);
-        directive.config = { compareFieldKey: '', isStrict: false };
+        directive.config = { fieldKey: '', isStrict: false };
 
         expect(directive.validate(control)).toEqual({ different: true });
     });

--- a/src/lib/directives/multi/nguard-different.directive.ts
+++ b/src/lib/directives/multi/nguard-different.directive.ts
@@ -1,8 +1,8 @@
 import { Directive, Input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 
-// Interfaces
-import { IComparable } from '../../interfaces/comparable.interface';
+// Types
+import { FieldComparisonConfig } from '../../types/field-comparison-config.type';
 
 // Validators
 import { MultiValidators } from '../../validators/multi.validators';
@@ -19,13 +19,13 @@ import { MultiValidators } from '../../validators/multi.validators';
     standalone: true,
 })
 export class NguardDifferentDirective implements Validator {
-    @Input('nguardDifferent') public config!: string | IComparable;
+    @Input('nguardDifferent') public config!: string | FieldComparisonConfig;
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
         const args: [string] | [string, boolean | undefined] =
-            typeof this.config === 'string' ? [this.config] : [this.config.compareFieldKey, this.config.isStrict];
+            typeof this.config === 'string' ? [this.config] : [this.config.fieldKey, this.config.isStrict];
 
         return MultiValidators.different.apply(this, args)(control);
     }

--- a/src/lib/directives/multi/nguard-required-if.directive.ts
+++ b/src/lib/directives/multi/nguard-required-if.directive.ts
@@ -1,7 +1,7 @@
 import { Directive, Input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 import { MultiValidators } from '../../validators/multi.validators';
-import { IRequiredIfConfig } from '../../interfaces/required-if-config.interface';
+import { FieldConditionConfig } from '../../types/field-condition-config.type';
 import { primitive } from '../../utils/validators.utils';
 
 @Directive({
@@ -16,7 +16,7 @@ import { primitive } from '../../utils/validators.utils';
     standalone: true,
 })
 export class NguardRequiredIfDirective implements Validator {
-    @Input('nguardRequiredIf') public config!: string | IRequiredIfConfig;
+    @Input('nguardRequiredIf') public config!: string | FieldConditionConfig;
 
     constructor() {}
 

--- a/src/lib/directives/multi/nguard-same.directive.spec.ts
+++ b/src/lib/directives/multi/nguard-same.directive.spec.ts
@@ -23,7 +23,7 @@ describe('NguardSameDirective', () => {
 
     it('should validate two fields with the same value', () => {
         control = createAbstractControlSpyWithSibling('abc', 'abc');
-        directive.config = { compareFieldKey: '' };
+        directive.config = { fieldKey: '' };
 
         expect(directive.validate(control)).toBeNull();
     });
@@ -37,21 +37,21 @@ describe('NguardSameDirective', () => {
 
     it('should fail if two fields have different values', () => {
         control = createAbstractControlSpyWithSibling('abc', 'def');
-        directive.config = { compareFieldKey: '' };
+        directive.config = { fieldKey: '' };
 
         expect(directive.validate(control)).toEqual({ same: true });
     });
 
     it('should validate two fields with the same value / different types (strict disabled)', () => {
         control = createAbstractControlSpyWithSibling('1', 1);
-        directive.config = { compareFieldKey: '', isStrict: false };
+        directive.config = { fieldKey: '', isStrict: false };
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should fail if two fields have the same value / different types (strict enabled)', () => {
         control = createAbstractControlSpyWithSibling('1', 1);
-        directive.config = { compareFieldKey: '', isStrict: true };
+        directive.config = { fieldKey: '', isStrict: true };
 
         expect(directive.validate(control)).toEqual({ same: true });
     });

--- a/src/lib/directives/multi/nguard-same.directive.ts
+++ b/src/lib/directives/multi/nguard-same.directive.ts
@@ -1,7 +1,7 @@
 import { Directive, Input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 import { MultiValidators } from '../../validators/multi.validators';
-import { IComparable } from '../../interfaces/comparable.interface';
+import { FieldComparisonConfig } from '../../types/field-comparison-config.type';
 
 @Directive({
     providers: [
@@ -15,13 +15,13 @@ import { IComparable } from '../../interfaces/comparable.interface';
     standalone: true,
 })
 export class NguardSameDirective implements Validator {
-    @Input('nguardSame') public config!: string | IComparable;
+    @Input('nguardSame') public config!: string | FieldComparisonConfig;
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
         const args: [string] | [string, boolean | undefined] =
-            typeof this.config === 'string' ? [this.config] : [this.config.compareFieldKey, this.config.isStrict];
+            typeof this.config === 'string' ? [this.config] : [this.config.fieldKey, this.config.isStrict];
 
         return MultiValidators.same.apply(this, args)(control);
     }

--- a/src/lib/directives/string/nguard-alpha-dash.directive.ts
+++ b/src/lib/directives/string/nguard-alpha-dash.directive.ts
@@ -1,8 +1,8 @@
 import { Directive, Input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 
-// Interfaces
-import { IAlphaDashDirectiveConfig } from '../../interfaces/alpha-dash-directive-config.interface';
+// Types
+import { CharsetConfig } from '../../types/charset-config.type';
 
 // Validators
 import { StringValidators } from '../../validators/string.validators';
@@ -19,7 +19,7 @@ import { StringValidators } from '../../validators/string.validators';
     standalone: true,
 })
 export class NguardAlphaDashDirective implements Validator {
-    @Input('nguardAlphaDash') public config!: IAlphaDashDirectiveConfig;
+    @Input('nguardAlphaDash') public config!: CharsetConfig;
 
     constructor() {}
 

--- a/src/lib/directives/string/nguard-alpha-num.directive.ts
+++ b/src/lib/directives/string/nguard-alpha-num.directive.ts
@@ -1,8 +1,8 @@
 import { Directive, Input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 
-// Interfaces
-import { IAlphaNumDirectiveConfig } from '../../interfaces/alpha-num-directive-config.interface';
+// Types
+import { CharsetConfig } from '../../types/charset-config.type';
 
 // Validators
 import { StringValidators } from '../../validators/string.validators';
@@ -19,7 +19,7 @@ import { StringValidators } from '../../validators/string.validators';
     standalone: true,
 })
 export class NguardAlphaNumDirective implements Validator {
-    @Input('nguardAlphaNum') public config!: IAlphaNumDirectiveConfig;
+    @Input('nguardAlphaNum') public config!: CharsetConfig;
 
     constructor() {}
 

--- a/src/lib/directives/string/nguard-alpha.directive.ts
+++ b/src/lib/directives/string/nguard-alpha.directive.ts
@@ -1,8 +1,8 @@
 import { Directive, Input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 
-// Interfaces
-import { IAlphaDirectiveConfig } from '../../interfaces/alpha-directive-config.interface';
+// Types
+import { CharsetConfig } from '../../types/charset-config.type';
 
 // Validators
 import { StringValidators } from '../../validators/string.validators';
@@ -19,7 +19,7 @@ import { StringValidators } from '../../validators/string.validators';
     standalone: true,
 })
 export class NguardAlphaDirective implements Validator {
-    @Input('nguardAlpha') public config!: IAlphaDirectiveConfig;
+    @Input('nguardAlpha') public config!: CharsetConfig;
 
     constructor() {}
 

--- a/src/lib/interfaces/alpha-dash-directive-config.interface.ts
+++ b/src/lib/interfaces/alpha-dash-directive-config.interface.ts
@@ -1,3 +1,0 @@
-export interface IAlphaDashDirectiveConfig {
-    hasAsciiOnly?: boolean;
-}

--- a/src/lib/interfaces/alpha-directive-config.interface.ts
+++ b/src/lib/interfaces/alpha-directive-config.interface.ts
@@ -1,3 +1,0 @@
-export interface IAlphaDirectiveConfig {
-    hasAsciiOnly?: boolean;
-}

--- a/src/lib/interfaces/alpha-num-directive-config.interface.ts
+++ b/src/lib/interfaces/alpha-num-directive-config.interface.ts
@@ -1,3 +1,0 @@
-export interface IAlphaNumDirectiveConfig {
-    hasAsciiOnly?: boolean;
-}

--- a/src/lib/interfaces/comparable.interface.ts
+++ b/src/lib/interfaces/comparable.interface.ts
@@ -1,4 +1,0 @@
-export interface IComparable {
-    compareFieldKey: string;
-    isStrict?: boolean;
-}

--- a/src/lib/interfaces/required-if-config.interface.ts
+++ b/src/lib/interfaces/required-if-config.interface.ts
@@ -1,7 +1,0 @@
-import { primitive } from '../utils/validators.utils';
-
-export interface IRequiredIfConfig {
-    fieldKey: string;
-    isStrict?: boolean;
-    value?: primitive;
-}

--- a/src/lib/types/charset-config.type.ts
+++ b/src/lib/types/charset-config.type.ts
@@ -1,0 +1,11 @@
+/**
+ * Configuration for validators that allow restricting the accepted character set
+ * to ASCII-only. Used by alpha, alphaDash, alphaNum and any future charset-aware validators.
+ */
+export type CharsetConfig = {
+    /**
+     * If true, restricts accepted characters to the ASCII range.
+     * If false or omitted, the full Unicode range applicable to the validator is allowed.
+     */
+    hasAsciiOnly?: boolean;
+};

--- a/src/lib/types/field-comparison-config.type.ts
+++ b/src/lib/types/field-comparison-config.type.ts
@@ -1,0 +1,17 @@
+/**
+ * Configuration for validators that compare the current field's value against another
+ * sibling field within the same form group. Used by same, different, greaterThan,
+ * greaterThanOrEqual, lesserThan, lesserThanOrEqual, confirmed and any future
+ * field-comparison validators.
+ */
+export type FieldComparisonConfig = {
+    /**
+     * The key of the sibling field to compare against.
+     */
+    fieldKey: string;
+    /**
+     * If true, equality checks are performed with the strict equality operator (===).
+     * If false or omitted, loose equality (==) is used and type coercion may apply.
+     */
+    isStrict?: boolean;
+};

--- a/src/lib/types/field-condition-config.type.ts
+++ b/src/lib/types/field-condition-config.type.ts
@@ -1,0 +1,23 @@
+import { primitive } from '../utils/validators.utils';
+
+/**
+ * Configuration for validators that apply a rule conditionally on the value of
+ * another sibling field within the same form group. Used by requiredIf and any
+ * future conditional validators (requiredUnless, requiredWith, prohibitedIf, ...).
+ */
+export type FieldConditionConfig = {
+    /**
+     * The key of the sibling field whose value triggers the condition.
+     */
+    fieldKey: string;
+    /**
+     * If true, equality checks against `value` are performed with the strict equality operator (===).
+     * If false or omitted, loose equality (==) is used and type coercion may apply.
+     */
+    isStrict?: boolean;
+    /**
+     * If provided, the sibling field must equal this value for the condition to trigger.
+     * If omitted, any truthy value of the sibling triggers the condition.
+     */
+    value?: primitive;
+};

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -2,12 +2,10 @@
  * Public API Surface of nguard
  */
 
-// Interfaces (Config types for directives)
-export * from './lib/interfaces/alpha-directive-config.interface';
-export * from './lib/interfaces/alpha-dash-directive-config.interface';
-export * from './lib/interfaces/alpha-num-directive-config.interface';
-export * from './lib/interfaces/comparable.interface';
-export * from './lib/interfaces/required-if-config.interface';
+// Types (config shapes for directives)
+export * from './lib/types/charset-config.type';
+export * from './lib/types/field-comparison-config.type';
+export * from './lib/types/field-condition-config.type';
 
 // Utility types
 export type { primitive } from './lib/utils/validators.utils';


### PR DESCRIPTION
## Summary

Phase 1 of the architectural refactor described in #12. Replaces the 5 per-directive interfaces with 3 shared types under `src/lib/types/`:

| Was | Now |
|---|---|
| `IAlphaDirectiveConfig`, `IAlphaDashDirectiveConfig`, `IAlphaNumDirectiveConfig` | `CharsetConfig` |
| `IComparable` (`compareFieldKey`) | `FieldComparisonConfig` (`fieldKey`) |
| `IRequiredIfConfig` | `FieldConditionConfig` |

Drops the `I` prefix and `.interface.ts` filename per the new workspace convention: interfaces only for class contracts, types for everything else.

The `compareFieldKey` → `fieldKey` rename also propagates to the `same` and `different` directive specs. The four `gt`/`gte`/`lt`/`lte` directives still use a bare `@Input() compareFieldKey` and are deferred to Phase 2 where they'll be standardized to the same shape.

## Test plan

- [ ] `ng build` compiles cleanly (no leftover references to `lib/interfaces/`)
- [ ] `npm test` passes the existing specs
- [ ] No remaining `IComparable` / `IAlpha*Config` / `IRequiredIfConfig` references in the codebase

## Phases (#12)

- [x] Phase 1 — Consolidate config types *(this PR)*
- [ ] Phase 2 — Migrate directives to input signals + standardized aliasing
- [ ] Phase 3 — Code hygiene (drop empty constructors, kill `any`, fix `.apply(this, args)`, fix JSDoc)
- [ ] Phase 4 — Update directive specs for input signals (TestBed-based pattern)
- [ ] Phase 5 — Validator function cleanup

Refs #12