### PR TITLE
Phase 2 of #12: migrate directives to input signals + standardized aliasing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "npm": ">=9.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^17.1.0",
-    "@angular/core": "^17.1.0",
-    "@angular/forms": "^17.1.0"
+    "@angular/common": ">=17.3.0 <23.0.0",
+    "@angular/core": ">=17.3.0 <23.0.0",
+    "@angular/forms": ">=17.3.0 <23.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/src/lib/directives/multi/nguard-confirmed.directive.ts
+++ b/src/lib/directives/multi/nguard-confirmed.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 import { MultiValidators } from '../../validators/multi.validators';
 
@@ -14,11 +14,11 @@ import { MultiValidators } from '../../validators/multi.validators';
     standalone: true,
 })
 export class NguardConfirmedDirective implements Validator {
-    @Input('nguardConfirmed') public fieldKey!: string;
+    public readonly fieldKey = input.required<string>({ alias: 'nguardConfirmed' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        return MultiValidators.confirmed(this.fieldKey)(control);
+        return MultiValidators.confirmed(this.fieldKey())(control);
     }
 }

--- a/src/lib/directives/multi/nguard-different.directive.spec.ts
+++ b/src/lib/directives/multi/nguard-different.directive.spec.ts
@@ -1,13 +1,20 @@
+import { ComponentFixture } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
 import { NguardDifferentDirective } from './nguard-different.directive';
-import { createAbstractControlSpyWithSibling } from '../../utils/test.utils';
+import { createAbstractControlSpyWithSibling, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
 
 describe('NguardDifferentDirective', () => {
     let control: AbstractControl;
     let directive: NguardDifferentDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
 
     beforeEach(() => {
-        directive = new NguardDifferentDirective();
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardDifferentDirective,
+            '<div [nguardDifferent]="$any(value)"></div>',
+            ''
+        ));
     });
 
     it('should create an instance', () => {
@@ -16,84 +23,94 @@ describe('NguardDifferentDirective', () => {
 
     it('should validate two fields with different values, simple string as config and same types (strict disabled / not given)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'def');
-        directive.config = '';
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate two fields with different values, same types (strict disabled / not given)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'def');
-        directive.config = { fieldKey: '' };
+        host.value = { fieldKey: '' };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate two fields with different values, same types (strict disabled / given)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'def');
-        directive.config = { fieldKey: '', isStrict: false };
+        host.value = { fieldKey: '', isStrict: false };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate two fields with different values, same types (strict enabled / given)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'def');
-        directive.config = { fieldKey: '', isStrict: true };
+        host.value = { fieldKey: '', isStrict: true };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate two fields with different values, different types (strict disabled / not given)', () => {
         control = createAbstractControlSpyWithSibling('1', 0);
-        directive.config = { fieldKey: '' };
+        host.value = { fieldKey: '' };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate two fields with different values, different types (strict disabled / given)', () => {
         control = createAbstractControlSpyWithSibling('1', 0);
-        directive.config = { fieldKey: '', isStrict: false };
+        host.value = { fieldKey: '', isStrict: false };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate two fields with different values, different types (strict enabled / given)', () => {
         control = createAbstractControlSpyWithSibling('1', 0);
-        directive.config = { fieldKey: '', isStrict: true };
+        host.value = { fieldKey: '', isStrict: true };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should fail if two fields have the same values (strict enabled / given)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'abc');
-        directive.config = { fieldKey: '', isStrict: true };
+        host.value = { fieldKey: '', isStrict: true };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ different: true });
     });
 
     it('should fail if two fields have the same values (strict disabled / given)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'abc');
-        directive.config = { fieldKey: '', isStrict: false };
+        host.value = { fieldKey: '', isStrict: false };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ different: true });
     });
 
     it('should fail if two fields have the same values (strict disabled / not given)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'abc');
-        directive.config = { fieldKey: '' };
+        host.value = { fieldKey: '' };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ different: true });
     });
 
     it('should fail if two fields have the same values but different types (strict disabled / not given)', () => {
         control = createAbstractControlSpyWithSibling('1', 1);
-        directive.config = { fieldKey: '' };
+        host.value = { fieldKey: '' };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ different: true });
     });
 
     it('should fail if two fields have the same values but different types (strict disabled / given)', () => {
         control = createAbstractControlSpyWithSibling('1', 1);
-        directive.config = { fieldKey: '', isStrict: false };
+        host.value = { fieldKey: '', isStrict: false };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ different: true });
     });

--- a/src/lib/directives/multi/nguard-different.directive.ts
+++ b/src/lib/directives/multi/nguard-different.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 
 // Types
@@ -19,14 +19,15 @@ import { MultiValidators } from '../../validators/multi.validators';
     standalone: true,
 })
 export class NguardDifferentDirective implements Validator {
-    @Input('nguardDifferent') public config!: string | FieldComparisonConfig;
+    public readonly config = input.required<string | FieldComparisonConfig>({ alias: 'nguardDifferent' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        const args: [string] | [string, boolean | undefined] =
-            typeof this.config === 'string' ? [this.config] : [this.config.fieldKey, this.config.isStrict];
+        const cfg = this.config();
+        const [fieldKey, isStrict]: [string, boolean | undefined] =
+            typeof cfg === 'string' ? [cfg, undefined] : [cfg.fieldKey, cfg.isStrict];
 
-        return MultiValidators.different.apply(this, args)(control);
+        return MultiValidators.different(fieldKey, isStrict)(control);
     }
 }

--- a/src/lib/directives/multi/nguard-doesnt-end-with.directive.spec.ts
+++ b/src/lib/directives/multi/nguard-doesnt-end-with.directive.spec.ts
@@ -1,13 +1,20 @@
+import { ComponentFixture } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
 import { NguardDoesntEndWithDirective } from './nguard-doesnt-end-with.directive';
-import { createAbstractControlSpy } from '../../utils/test.utils';
+import { createAbstractControlSpy, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
 
 describe('NguardDoesntEndWithDirective', () => {
     let control: AbstractControl;
     let directive: NguardDoesntEndWithDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
 
     beforeEach(() => {
-        directive = new NguardDoesntEndWithDirective();
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardDoesntEndWithDirective,
+            '<div [nguardDoesntEndWith]="$any(value)"></div>',
+            'C12'
+        ));
     });
 
     it('should create an instance', () => {
@@ -16,35 +23,38 @@ describe('NguardDoesntEndWithDirective', () => {
 
     it('should validate a field that doesnt end with (single value / no array)', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = 'C12';
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate a field that doesnt end with', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = ['abc', 'C12'];
+        host.value = ['abc', 'C12'];
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should fail if the field ends with (single value / no array)', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = '123';
+        host.value = '123';
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ doesntEndWith: true });
     });
 
     it('should fail if the field ends with', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = ['123'];
+        host.value = ['123'];
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ doesntEndWith: true });
     });
 
     it('should fail if the field ends with (mixed types)', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = [123];
+        host.value = [123];
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ doesntEndWith: true });
     });

--- a/src/lib/directives/multi/nguard-doesnt-end-with.directive.ts
+++ b/src/lib/directives/multi/nguard-doesnt-end-with.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 
 // Types
@@ -19,12 +19,13 @@ import { MultiValidators } from '../../validators/multi.validators';
     standalone: true,
 })
 export class NguardDoesntEndWithDirective implements Validator {
-    @Input('nguardDoesntEndWith') public values!: primitive | primitive[];
+    public readonly values = input.required<primitive | primitive[]>({ alias: 'nguardDoesntEndWith' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        const values = Array.isArray(this.values) ? this.values : [this.values];
+        const raw = this.values();
+        const values = Array.isArray(raw) ? raw : [raw];
         return MultiValidators.doesntEndWith(...values)(control);
     }
 }

--- a/src/lib/directives/multi/nguard-doesnt-start-with.directive.spec.ts
+++ b/src/lib/directives/multi/nguard-doesnt-start-with.directive.spec.ts
@@ -1,13 +1,20 @@
+import { ComponentFixture } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
 import { NguardDoesntStartWithDirective } from './nguard-doesnt-start-with.directive';
-import { createAbstractControlSpy } from '../../utils/test.utils';
+import { createAbstractControlSpy, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
 
 describe('NguardDoesntStartWithDirective', () => {
     let control: AbstractControl;
     let directive: NguardDoesntStartWithDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
 
     beforeEach(() => {
-        directive = new NguardDoesntStartWithDirective();
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardDoesntStartWithDirective,
+            '<div [nguardDoesntStartWith]="$any(value)"></div>',
+            'C12'
+        ));
     });
 
     it('should create an instance', () => {
@@ -16,35 +23,38 @@ describe('NguardDoesntStartWithDirective', () => {
 
     it('should validate a field that doesnt start with (single value / no array)', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = 'C12';
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate a field that doesnt start with', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = ['123', 'def'];
+        host.value = ['123', 'def'];
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should fail if the field starts with (single value / no array)', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = 'abc';
+        host.value = 'abc';
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ doesntStartWith: true });
     });
 
     it('should fail if the field starts with', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = ['abc'];
+        host.value = ['abc'];
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ doesntStartWith: true });
     });
 
     it('should fail if the field starts with (mixed types)', () => {
         control = createAbstractControlSpy('123abc');
-        directive.values = [123];
+        host.value = [123];
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ doesntStartWith: true });
     });

--- a/src/lib/directives/multi/nguard-doesnt-start-with.directive.ts
+++ b/src/lib/directives/multi/nguard-doesnt-start-with.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 
 // Types
@@ -19,12 +19,13 @@ import { MultiValidators } from '../../validators/multi.validators';
     standalone: true,
 })
 export class NguardDoesntStartWithDirective implements Validator {
-    @Input('nguardDoesntStartWith') public values!: primitive | primitive[];
+    public readonly values = input.required<primitive | primitive[]>({ alias: 'nguardDoesntStartWith' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        const values = Array.isArray(this.values) ? this.values : [this.values];
+        const raw = this.values();
+        const values = Array.isArray(raw) ? raw : [raw];
         return MultiValidators.doesntStartWith(...values)(control);
     }
 }

--- a/src/lib/directives/multi/nguard-ends-with.directive.spec.ts
+++ b/src/lib/directives/multi/nguard-ends-with.directive.spec.ts
@@ -1,13 +1,20 @@
+import { ComponentFixture } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
 import { NguardEndsWithDirective } from './nguard-ends-with.directive';
-import { createAbstractControlSpy } from '../../utils/test.utils';
+import { createAbstractControlSpy, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
 
 describe('NguardEndsWithDirective', () => {
     let control: AbstractControl;
     let directive: NguardEndsWithDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
 
     beforeEach(() => {
-        directive = new NguardEndsWithDirective();
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardEndsWithDirective,
+            '<div [nguardEndsWith]="$any(value)"></div>',
+            '123'
+        ));
     });
 
     it('should create an instance', () => {
@@ -16,35 +23,38 @@ describe('NguardEndsWithDirective', () => {
 
     it('should validate a field that ends with (single value / no array)', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = '123';
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate a field that ends with', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = ['123', '456'];
+        host.value = ['123', '456'];
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should fail if the field doesnt ends with (single value / no array)', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = '12';
+        host.value = '12';
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ endsWith: true });
     });
 
     it('should fail if the field doesnt ends with', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = ['abc', '12'];
+        host.value = ['abc', '12'];
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ endsWith: true });
     });
 
     it('should validate a field that ends with (number)', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = [123, '456'];
+        host.value = [123, '456'];
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });

--- a/src/lib/directives/multi/nguard-ends-with.directive.ts
+++ b/src/lib/directives/multi/nguard-ends-with.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 
 // Types
@@ -19,12 +19,13 @@ import { MultiValidators } from '../../validators/multi.validators';
     standalone: true,
 })
 export class NguardEndsWithDirective implements Validator {
-    @Input('nguardEndsWith') public values!: primitive | primitive[];
+    public readonly values = input.required<primitive | primitive[]>({ alias: 'nguardEndsWith' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        const values = Array.isArray(this.values) ? this.values : [this.values];
+        const raw = this.values();
+        const values = Array.isArray(raw) ? raw : [raw];
         return MultiValidators.endsWith(...values)(control);
     }
 }

--- a/src/lib/directives/multi/nguard-greater-than-or-equal.directive.spec.ts
+++ b/src/lib/directives/multi/nguard-greater-than-or-equal.directive.spec.ts
@@ -1,12 +1,17 @@
-import { createAbstractControlSpyWithSibling } from '../../utils/test.utils';
+import { AbstractControl } from '@angular/forms';
 import { NguardGreaterThanOrEqualDirective } from './nguard-greater-than-or-equal.directive';
+import { createAbstractControlSpyWithSibling, createDirectiveFixture } from '../../utils/test.utils';
 
-describe('LesserThanDirective', () => {
-    let control;
+describe('NguardGreaterThanOrEqualDirective', () => {
+    let control: AbstractControl;
     let directive: NguardGreaterThanOrEqualDirective;
 
     beforeEach(() => {
-        directive = new NguardGreaterThanOrEqualDirective();
+        ({ directive } = createDirectiveFixture(
+            NguardGreaterThanOrEqualDirective,
+            '<div [nguardGreaterThanOrEqual]="$any(value)"></div>',
+            ''
+        ));
     });
 
     it('should create an instance', () => {
@@ -15,21 +20,18 @@ describe('LesserThanDirective', () => {
 
     it('should validate two fields of the same type (strings)', () => {
         control = createAbstractControlSpyWithSibling('defghi', 'abc');
-        directive.compareFieldKey = '';
 
         expect(directive.validate(control)).toBeNull();
     });
 
-    it('should fail with the first value not lesser than the second', () => {
+    it('should fail with the first value not greater than or equal to the second', () => {
         control = createAbstractControlSpyWithSibling(1, 10);
-        directive.compareFieldKey = '';
 
         expect(directive.validate(control)).toEqual({ greaterThanOrEqual: true });
     });
 
     it('should fail with two fields of different types', () => {
         control = createAbstractControlSpyWithSibling('1', 10);
-        directive.compareFieldKey = '';
 
         expect(directive.validate(control)).toEqual({ greaterThanOrEqual: true });
     });

--- a/src/lib/directives/multi/nguard-greater-than-or-equal.directive.ts
+++ b/src/lib/directives/multi/nguard-greater-than-or-equal.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 import { MultiValidators } from '../../validators/multi.validators';
 
@@ -14,11 +14,11 @@ import { MultiValidators } from '../../validators/multi.validators';
     standalone: true,
 })
 export class NguardGreaterThanOrEqualDirective implements Validator {
-    @Input() public compareFieldKey!: string;
+    public readonly fieldKey = input.required<string>({ alias: 'nguardGreaterThanOrEqual' });
 
     constructor() {}
 
-    public validate(control: AbstractControl): ValidationErrors | null {
-        return MultiValidators.greaterThanOrEqual(this.compareFieldKey)(control);
+    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+        return MultiValidators.greaterThanOrEqual(this.fieldKey())(control);
     }
 }

--- a/src/lib/directives/multi/nguard-greater-than.directive.spec.ts
+++ b/src/lib/directives/multi/nguard-greater-than.directive.spec.ts
@@ -1,12 +1,17 @@
-import { createAbstractControlSpyWithSibling } from '../../utils/test.utils';
+import { AbstractControl } from '@angular/forms';
 import { NguardGreaterThanDirective } from './nguard-greater-than.directive';
+import { createAbstractControlSpyWithSibling, createDirectiveFixture } from '../../utils/test.utils';
 
-describe('LesserThanDirective', () => {
-    let control;
+describe('NguardGreaterThanDirective', () => {
+    let control: AbstractControl;
     let directive: NguardGreaterThanDirective;
 
     beforeEach(() => {
-        directive = new NguardGreaterThanDirective();
+        ({ directive } = createDirectiveFixture(
+            NguardGreaterThanDirective,
+            '<div [nguardGreaterThan]="$any(value)"></div>',
+            ''
+        ));
     });
 
     it('should create an instance', () => {
@@ -15,21 +20,18 @@ describe('LesserThanDirective', () => {
 
     it('should validate two fields of the same type (strings)', () => {
         control = createAbstractControlSpyWithSibling('defghi', 'abc');
-        directive.compareFieldKey = '';
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should fail with the first value not greater than the second', () => {
         control = createAbstractControlSpyWithSibling(1, 10);
-        directive.compareFieldKey = '';
 
         expect(directive.validate(control)).toEqual({ greaterThan: true });
     });
 
     it('should fail with two fields of different types', () => {
         control = createAbstractControlSpyWithSibling('1', 10);
-        directive.compareFieldKey = '';
 
         expect(directive.validate(control)).toEqual({ greaterThan: true });
     });

--- a/src/lib/directives/multi/nguard-greater-than.directive.ts
+++ b/src/lib/directives/multi/nguard-greater-than.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 import { MultiValidators } from '../../validators/multi.validators';
 
@@ -14,11 +14,11 @@ import { MultiValidators } from '../../validators/multi.validators';
     standalone: true,
 })
 export class NguardGreaterThanDirective implements Validator {
-    @Input() public compareFieldKey!: string;
+    public readonly fieldKey = input.required<string>({ alias: 'nguardGreaterThan' });
 
     constructor() {}
 
-    public validate(control: AbstractControl): ValidationErrors | null {
-        return MultiValidators.greaterThan(this.compareFieldKey)(control);
+    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+        return MultiValidators.greaterThan(this.fieldKey())(control);
     }
 }

--- a/src/lib/directives/multi/nguard-lesser-than-or-equal.directive.spec.ts
+++ b/src/lib/directives/multi/nguard-lesser-than-or-equal.directive.spec.ts
@@ -1,12 +1,17 @@
-import { createAbstractControlSpyWithSibling } from '../../utils/test.utils';
+import { AbstractControl } from '@angular/forms';
 import { NguardLesserThanOrEqualDirective } from './nguard-lesser-than-or-equal.directive';
+import { createAbstractControlSpyWithSibling, createDirectiveFixture } from '../../utils/test.utils';
 
-describe('LesserThanDirective', () => {
-    let control;
+describe('NguardLesserThanOrEqualDirective', () => {
+    let control: AbstractControl;
     let directive: NguardLesserThanOrEqualDirective;
 
     beforeEach(() => {
-        directive = new NguardLesserThanOrEqualDirective();
+        ({ directive } = createDirectiveFixture(
+            NguardLesserThanOrEqualDirective,
+            '<div [nguardLesserThanOrEqual]="$any(value)"></div>',
+            ''
+        ));
     });
 
     it('should create an instance', () => {
@@ -15,21 +20,18 @@ describe('LesserThanDirective', () => {
 
     it('should validate two fields of the same type (strings)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'defghi');
-        directive.compareFieldKey = '';
 
         expect(directive.validate(control)).toBeNull();
     });
 
-    it('should fail with the first value not lesser than the second', () => {
+    it('should fail with the first value not lesser than or equal to the second', () => {
         control = createAbstractControlSpyWithSibling(10, 1);
-        directive.compareFieldKey = '';
 
         expect(directive.validate(control)).toEqual({ lesserThanOrEqual: true });
     });
 
     it('should fail with two fields of different types', () => {
         control = createAbstractControlSpyWithSibling('1', 10);
-        directive.compareFieldKey = '';
 
         expect(directive.validate(control)).toEqual({ lesserThanOrEqual: true });
     });

--- a/src/lib/directives/multi/nguard-lesser-than-or-equal.directive.ts
+++ b/src/lib/directives/multi/nguard-lesser-than-or-equal.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 import { MultiValidators } from '../../validators/multi.validators';
 
@@ -14,11 +14,11 @@ import { MultiValidators } from '../../validators/multi.validators';
     standalone: true,
 })
 export class NguardLesserThanOrEqualDirective implements Validator {
-    @Input() public compareFieldKey!: string;
+    public readonly fieldKey = input.required<string>({ alias: 'nguardLesserThanOrEqual' });
 
     constructor() {}
 
-    public validate(control: AbstractControl): ValidationErrors | null {
-        return MultiValidators.lesserThanOrEqual(this.compareFieldKey)(control);
+    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+        return MultiValidators.lesserThanOrEqual(this.fieldKey())(control);
     }
 }

--- a/src/lib/directives/multi/nguard-lesser-than.directive.spec.ts
+++ b/src/lib/directives/multi/nguard-lesser-than.directive.spec.ts
@@ -1,12 +1,17 @@
-import { createAbstractControlSpyWithSibling } from '../../utils/test.utils';
+import { AbstractControl } from '@angular/forms';
 import { NguardLesserThanDirective } from './nguard-lesser-than.directive';
+import { createAbstractControlSpyWithSibling, createDirectiveFixture } from '../../utils/test.utils';
 
-describe('LesserThanDirective', () => {
-    let control;
+describe('NguardLesserThanDirective', () => {
+    let control: AbstractControl;
     let directive: NguardLesserThanDirective;
 
     beforeEach(() => {
-        directive = new NguardLesserThanDirective();
+        ({ directive } = createDirectiveFixture(
+            NguardLesserThanDirective,
+            '<div [nguardLesserThan]="$any(value)"></div>',
+            ''
+        ));
     });
 
     it('should create an instance', () => {
@@ -15,21 +20,18 @@ describe('LesserThanDirective', () => {
 
     it('should validate two fields of the same type (strings)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'defghi');
-        directive.compareFieldKey = '';
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should fail with the first value not lesser than the second', () => {
         control = createAbstractControlSpyWithSibling(10, 1);
-        directive.compareFieldKey = '';
 
         expect(directive.validate(control)).toEqual({ lesserThan: true });
     });
 
     it('should fail with two fields of different types', () => {
         control = createAbstractControlSpyWithSibling('1', 10);
-        directive.compareFieldKey = '';
 
         expect(directive.validate(control)).toEqual({ lesserThan: true });
     });

--- a/src/lib/directives/multi/nguard-lesser-than.directive.ts
+++ b/src/lib/directives/multi/nguard-lesser-than.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 import { MultiValidators } from '../../validators/multi.validators';
 
@@ -14,11 +14,11 @@ import { MultiValidators } from '../../validators/multi.validators';
     standalone: true,
 })
 export class NguardLesserThanDirective implements Validator {
-    @Input() public compareFieldKey!: string;
+    public readonly fieldKey = input.required<string>({ alias: 'nguardLesserThan' });
 
     constructor() {}
 
-    public validate(control: AbstractControl): ValidationErrors | null {
-        return MultiValidators.lesserThan(this.compareFieldKey)(control);
+    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+        return MultiValidators.lesserThan(this.fieldKey())(control);
     }
 }

--- a/src/lib/directives/multi/nguard-required-if.directive.spec.ts
+++ b/src/lib/directives/multi/nguard-required-if.directive.spec.ts
@@ -1,13 +1,20 @@
+import { ComponentFixture } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
 import { NguardRequiredIfDirective } from './nguard-required-if.directive';
-import { createAbstractControlSpyWithSibling } from '../../utils/test.utils';
+import { createAbstractControlSpyWithSibling, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
 
 describe('NguardRequiredIfDirective', () => {
     let control: AbstractControl;
     let directive: NguardRequiredIfDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
 
     beforeEach(() => {
-        directive = new NguardRequiredIfDirective();
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardRequiredIfDirective,
+            '<div [nguardRequiredIf]="$any(value)"></div>',
+            'fieldKey'
+        ));
     });
 
     it('should create an instance', () => {
@@ -16,35 +23,38 @@ describe('NguardRequiredIfDirective', () => {
 
     it('should validate if both the fields are set / config as string', () => {
         control = createAbstractControlSpyWithSibling('value1', 'value2');
-        directive.config = 'fieldKey';
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate if both the fields are set / config as object - fieldKey only', () => {
         control = createAbstractControlSpyWithSibling('value1', 'value2');
-        directive.config = { fieldKey: 'fieldKey' };
+        host.value = { fieldKey: 'fieldKey' };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate if both the fields are set / config as object - fieldKey and value', () => {
         control = createAbstractControlSpyWithSibling('value1', 'value2');
-        directive.config = { fieldKey: 'fieldKey', value: 'value2' };
+        host.value = { fieldKey: 'fieldKey', value: 'value2' };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate if both the fields are set / config as object - fieldKey and value, non strict', () => {
         control = createAbstractControlSpyWithSibling('value1', '1');
-        directive.config = { fieldKey: 'fieldKey', value: 1 };
+        host.value = { fieldKey: 'fieldKey', value: 1 };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should fail if both the fields are set / config as object - fieldKey and value of different types, strict', () => {
         control = createAbstractControlSpyWithSibling('value1', '1');
-        directive.config = { fieldKey: 'fieldKey', isStrict: true, value: 1 };
+        host.value = { fieldKey: 'fieldKey', isStrict: true, value: 1 };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ requiredIf: true });
     });

--- a/src/lib/directives/multi/nguard-required-if.directive.ts
+++ b/src/lib/directives/multi/nguard-required-if.directive.ts
@@ -1,8 +1,7 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 import { MultiValidators } from '../../validators/multi.validators';
 import { FieldConditionConfig } from '../../types/field-condition-config.type';
-import { primitive } from '../../utils/validators.utils';
 
 @Directive({
     providers: [
@@ -16,19 +15,15 @@ import { primitive } from '../../utils/validators.utils';
     standalone: true,
 })
 export class NguardRequiredIfDirective implements Validator {
-    @Input('nguardRequiredIf') public config!: string | FieldConditionConfig;
+    public readonly config = input.required<string | FieldConditionConfig>({ alias: 'nguardRequiredIf' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        const fieldKey = typeof this.config === 'string' ? this.config : this.config.fieldKey;
-
-        let isStrict: boolean | undefined, value: primitive | undefined;
-
-        if (typeof this.config === 'object') {
-            isStrict = this.config?.isStrict;
-            value = this.config?.value;
-        }
+        const cfg = this.config();
+        const fieldKey = typeof cfg === 'string' ? cfg : cfg.fieldKey;
+        const isStrict = typeof cfg === 'string' ? undefined : cfg.isStrict;
+        const value = typeof cfg === 'string' ? undefined : cfg.value;
 
         return MultiValidators.requiredIf(fieldKey, value, isStrict)(control);
     }

--- a/src/lib/directives/multi/nguard-same.directive.spec.ts
+++ b/src/lib/directives/multi/nguard-same.directive.spec.ts
@@ -1,13 +1,20 @@
+import { ComponentFixture } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
 import { NguardSameDirective } from './nguard-same.directive';
-import { createAbstractControlSpyWithSibling } from '../../utils/test.utils';
+import { createAbstractControlSpyWithSibling, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
 
 describe('NguardSameDirective', () => {
     let control: AbstractControl;
     let directive: NguardSameDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
 
     beforeEach(() => {
-        directive = new NguardSameDirective();
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardSameDirective,
+            '<div [nguardSame]="$any(value)"></div>',
+            ''
+        ));
     });
 
     it('should create an instance', () => {
@@ -16,42 +23,44 @@ describe('NguardSameDirective', () => {
 
     it('should validate two fields with the same value (field name only / no object)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'abc');
-        directive.config = '';
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate two fields with the same value', () => {
         control = createAbstractControlSpyWithSibling('abc', 'abc');
-        directive.config = { fieldKey: '' };
+        host.value = { fieldKey: '' };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should fail if two fields have different values (field name only / no object)', () => {
         control = createAbstractControlSpyWithSibling('abc', 'def');
-        directive.config = '';
 
         expect(directive.validate(control)).toEqual({ same: true });
     });
 
     it('should fail if two fields have different values', () => {
         control = createAbstractControlSpyWithSibling('abc', 'def');
-        directive.config = { fieldKey: '' };
+        host.value = { fieldKey: '' };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ same: true });
     });
 
     it('should validate two fields with the same value / different types (strict disabled)', () => {
         control = createAbstractControlSpyWithSibling('1', 1);
-        directive.config = { fieldKey: '', isStrict: false };
+        host.value = { fieldKey: '', isStrict: false };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should fail if two fields have the same value / different types (strict enabled)', () => {
         control = createAbstractControlSpyWithSibling('1', 1);
-        directive.config = { fieldKey: '', isStrict: true };
+        host.value = { fieldKey: '', isStrict: true };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ same: true });
     });

--- a/src/lib/directives/multi/nguard-same.directive.ts
+++ b/src/lib/directives/multi/nguard-same.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 import { MultiValidators } from '../../validators/multi.validators';
 import { FieldComparisonConfig } from '../../types/field-comparison-config.type';
@@ -15,14 +15,15 @@ import { FieldComparisonConfig } from '../../types/field-comparison-config.type'
     standalone: true,
 })
 export class NguardSameDirective implements Validator {
-    @Input('nguardSame') public config!: string | FieldComparisonConfig;
+    public readonly config = input.required<string | FieldComparisonConfig>({ alias: 'nguardSame' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        const args: [string] | [string, boolean | undefined] =
-            typeof this.config === 'string' ? [this.config] : [this.config.fieldKey, this.config.isStrict];
+        const cfg = this.config();
+        const [fieldKey, isStrict]: [string, boolean | undefined] =
+            typeof cfg === 'string' ? [cfg, undefined] : [cfg.fieldKey, cfg.isStrict];
 
-        return MultiValidators.same.apply(this, args)(control);
+        return MultiValidators.same(fieldKey, isStrict)(control);
     }
 }

--- a/src/lib/directives/multi/nguard-starts-with.directive.spec.ts
+++ b/src/lib/directives/multi/nguard-starts-with.directive.spec.ts
@@ -1,13 +1,20 @@
+import { ComponentFixture } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
 import { NguardStartsWithDirective } from './nguard-starts-with.directive';
-import { createAbstractControlSpy } from '../../utils/test.utils';
+import { createAbstractControlSpy, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
 
 describe('NguardStartsWithDirective', () => {
     let control: AbstractControl;
     let directive: NguardStartsWithDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
 
     beforeEach(() => {
-        directive = new NguardStartsWithDirective();
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardStartsWithDirective,
+            '<div [nguardStartsWith]="$any(value)"></div>',
+            'abc'
+        ));
     });
 
     it('should create an instance', () => {
@@ -16,28 +23,30 @@ describe('NguardStartsWithDirective', () => {
 
     it('should validate a field that starts with (single value / no array)', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = 'abc';
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate a field that starts with', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = ['123', 'abc'];
+        host.value = ['123', 'abc'];
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should fail if the field doesnt start with (single value / no array)', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = '123';
+        host.value = '123';
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ startsWith: true });
     });
 
     it('should fail if the field doesnt start with', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.values = ['123', '456'];
+        host.value = ['123', '456'];
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ startsWith: true });
     });

--- a/src/lib/directives/multi/nguard-starts-with.directive.ts
+++ b/src/lib/directives/multi/nguard-starts-with.directive.ts
@@ -1,7 +1,7 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 
-// Interfaces
+// Types
 import { primitive } from '../../utils/validators.utils';
 
 // Validators
@@ -19,12 +19,13 @@ import { MultiValidators } from '../../validators/multi.validators';
     standalone: true,
 })
 export class NguardStartsWithDirective implements Validator {
-    @Input('nguardStartsWith') public values!: primitive | primitive[];
+    public readonly values = input.required<primitive | primitive[]>({ alias: 'nguardStartsWith' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        const values = Array.isArray(this.values) ? this.values : [this.values];
+        const raw = this.values();
+        const values = Array.isArray(raw) ? raw : [raw];
         return MultiValidators.startsWith(...values)(control);
     }
 }

--- a/src/lib/directives/number/nguard-between.directive.ts
+++ b/src/lib/directives/number/nguard-between.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 import { NumberValidators } from '../../validators/number.validators';
 
@@ -14,11 +14,11 @@ import { NumberValidators } from '../../validators/number.validators';
     standalone: true,
 })
 export class NguardBetweenDirective implements Validator {
-    @Input('nguardBetween') public values!: [number, number];
+    public readonly values = input.required<[number, number]>({ alias: 'nguardBetween' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        return NumberValidators.between(...this.values)(control);
+        return NumberValidators.between(...this.values())(control);
     }
 }

--- a/src/lib/directives/number/nguard-max.directive.ts
+++ b/src/lib/directives/number/nguard-max.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 import { NumberValidators } from '../../validators/number.validators';
 
@@ -14,11 +14,11 @@ import { NumberValidators } from '../../validators/number.validators';
     standalone: true,
 })
 export class NguardMaxDirective implements Validator {
-    @Input('nguardMax') public maxVal!: number;
+    public readonly maxVal = input.required<number>({ alias: 'nguardMax' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        return NumberValidators.max(this.maxVal)(control);
+        return NumberValidators.max(this.maxVal())(control);
     }
 }

--- a/src/lib/directives/number/nguard-min.directive.ts
+++ b/src/lib/directives/number/nguard-min.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 import { NumberValidators } from '../../validators/number.validators';
 
@@ -14,11 +14,11 @@ import { NumberValidators } from '../../validators/number.validators';
     standalone: true,
 })
 export class NguardMinDirective implements Validator {
-    @Input('nguardMin') public minVal!: number;
+    public readonly minVal = input.required<number>({ alias: 'nguardMin' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        return NumberValidators.min(this.minVal)(control);
+        return NumberValidators.min(this.minVal())(control);
     }
 }

--- a/src/lib/directives/number/nguard-range.directive.spec.ts
+++ b/src/lib/directives/number/nguard-range.directive.spec.ts
@@ -1,31 +1,37 @@
+import { ComponentFixture } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
 import { NguardRangeDirective } from './nguard-range.directive';
-import { createAbstractControlSpy } from '../../utils/test.utils';
+import { createAbstractControlSpy, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
 
 describe('NguardRangeDirective', () => {
     let control: AbstractControl;
     let directive: NguardRangeDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
 
     beforeEach(() => {
-        directive = new NguardRangeDirective();
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardRangeDirective,
+            '<div [nguardRange]="$any(value)"></div>'
+        ));
     });
 
     it('should create an instance', () => {
-        const directive = new NguardRangeDirective();
-
         expect(directive).toBeTruthy();
     });
 
     it('Should validate a number in the given range', () => {
         control = createAbstractControlSpy(5);
-        directive.values = [1, 5];
+        host.value = [1, 5];
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('Should validate a number is not in the given range', () => {
         control = createAbstractControlSpy(7);
-        directive.values = [1, 5];
+        host.value = [1, 5];
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ range: true });
     });

--- a/src/lib/directives/number/nguard-range.directive.ts
+++ b/src/lib/directives/number/nguard-range.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 import { NumberValidators } from '../../validators/number.validators';
 
@@ -14,11 +14,11 @@ import { NumberValidators } from '../../validators/number.validators';
     standalone: true,
 })
 export class NguardRangeDirective implements Validator {
-    @Input('nguardRange') public values!: [number, number];
+    public readonly values = input.required<[number, number]>({ alias: 'nguardRange' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        return NumberValidators.range(...this.values)(control);
+        return NumberValidators.range(...this.values())(control);
     }
 }

--- a/src/lib/directives/string/nguard-alpha-dash.directive.spec.ts
+++ b/src/lib/directives/string/nguard-alpha-dash.directive.spec.ts
@@ -1,13 +1,19 @@
+import { ComponentFixture } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
 import { NguardAlphaDashDirective } from './nguard-alpha-dash.directive';
-import { createAbstractControlSpy } from '../../utils/test.utils';
+import { createAbstractControlSpy, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
 
 describe('NguardAlphaDashDirective', () => {
     let control: AbstractControl;
     let directive: NguardAlphaDashDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
 
     beforeEach(() => {
-        directive = new NguardAlphaDashDirective();
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardAlphaDashDirective,
+            '<div [nguardAlphaDash]="$any(value)"></div>'
+        ));
     });
 
     it('should create an instance', () => {
@@ -16,14 +22,16 @@ describe('NguardAlphaDashDirective', () => {
 
     it('should validate a properly formatted value (ASCII true)', () => {
         control = createAbstractControlSpy('abcABC_-123');
-        directive.config = { hasAsciiOnly: true };
+        host.value = { hasAsciiOnly: true };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate a non properly formatted value (ASCII true)', () => {
         control = createAbstractControlSpy('a 2 c');
-        directive.config = { hasAsciiOnly: true };
+        host.value = { hasAsciiOnly: true };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ alphaDash: true });
     });

--- a/src/lib/directives/string/nguard-alpha-dash.directive.ts
+++ b/src/lib/directives/string/nguard-alpha-dash.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 
 // Types
@@ -19,11 +19,11 @@ import { StringValidators } from '../../validators/string.validators';
     standalone: true,
 })
 export class NguardAlphaDashDirective implements Validator {
-    @Input('nguardAlphaDash') public config!: CharsetConfig;
+    public readonly config = input<CharsetConfig | undefined>(undefined, { alias: 'nguardAlphaDash' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        return StringValidators.alphaDash(this.config?.hasAsciiOnly)(control);
+        return StringValidators.alphaDash(this.config()?.hasAsciiOnly)(control);
     }
 }

--- a/src/lib/directives/string/nguard-alpha-num.directive.spec.ts
+++ b/src/lib/directives/string/nguard-alpha-num.directive.spec.ts
@@ -1,13 +1,19 @@
+import { ComponentFixture } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
 import { NguardAlphaNumDirective } from './nguard-alpha-num.directive';
-import { createAbstractControlSpy } from '../../utils/test.utils';
+import { createAbstractControlSpy, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
 
 describe('NguardAlphaNumDirective', () => {
     let control: AbstractControl;
     let directive: NguardAlphaNumDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
 
     beforeEach(() => {
-        directive = new NguardAlphaNumDirective();
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardAlphaNumDirective,
+            '<div [nguardAlphaNum]="$any(value)"></div>'
+        ));
     });
 
     it('should create an instance', () => {
@@ -16,14 +22,16 @@ describe('NguardAlphaNumDirective', () => {
 
     it('should validate a properly formatted value (ASCII true)', () => {
         control = createAbstractControlSpy('abcABC123');
-        directive.config = { hasAsciiOnly: true };
+        host.value = { hasAsciiOnly: true };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate a non properly formatted value (ASCII true)', () => {
         control = createAbstractControlSpy('a 2-c');
-        directive.config = { hasAsciiOnly: true };
+        host.value = { hasAsciiOnly: true };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ alphaNum: true });
     });

--- a/src/lib/directives/string/nguard-alpha-num.directive.ts
+++ b/src/lib/directives/string/nguard-alpha-num.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 
 // Types
@@ -19,11 +19,11 @@ import { StringValidators } from '../../validators/string.validators';
     standalone: true,
 })
 export class NguardAlphaNumDirective implements Validator {
-    @Input('nguardAlphaNum') public config!: CharsetConfig;
+    public readonly config = input<CharsetConfig | undefined>(undefined, { alias: 'nguardAlphaNum' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        return StringValidators.alphaNum(this.config?.hasAsciiOnly)(control);
+        return StringValidators.alphaNum(this.config()?.hasAsciiOnly)(control);
     }
 }

--- a/src/lib/directives/string/nguard-alpha.directive.spec.ts
+++ b/src/lib/directives/string/nguard-alpha.directive.spec.ts
@@ -1,13 +1,19 @@
+import { ComponentFixture } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
 import { NguardAlphaDirective } from './nguard-alpha.directive';
-import { createAbstractControlSpy } from '../../utils/test.utils';
+import { createAbstractControlSpy, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
 
 describe('NguardAlphaDirective', () => {
     let control: AbstractControl;
     let directive: NguardAlphaDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
 
     beforeEach(() => {
-        directive = new NguardAlphaDirective();
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardAlphaDirective,
+            '<div [nguardAlpha]="$any(value)"></div>'
+        ));
     });
 
     it('should create an instance', () => {
@@ -16,14 +22,16 @@ describe('NguardAlphaDirective', () => {
 
     it('should validate a properly formatted value (ASCII true)', () => {
         control = createAbstractControlSpy('abc');
-        directive.config = { hasAsciiOnly: true };
+        host.value = { hasAsciiOnly: true };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toBeNull();
     });
 
     it('should validate a non properly formatted value (ASCII true)', () => {
         control = createAbstractControlSpy('a2c');
-        directive.config = { hasAsciiOnly: true };
+        host.value = { hasAsciiOnly: true };
+        fixture.detectChanges();
 
         expect(directive.validate(control)).toEqual({ alpha: true });
     });
@@ -57,42 +65,46 @@ describe('NguardAlphaDirective', () => {
     describe('Edge Cases', () => {
         it('should handle undefined config', () => {
             control = createAbstractControlSpy('abc');
-            directive.config = undefined as any;
 
             expect(directive.validate(control)).toBeNull();
         });
 
         it('should handle null config', () => {
             control = createAbstractControlSpy('abc');
-            directive.config = null as any;
+            host.value = null;
+            fixture.detectChanges();
 
             expect(directive.validate(control)).toBeNull();
         });
 
         it('should handle empty config object', () => {
             control = createAbstractControlSpy('abc');
-            directive.config = {} as any;
+            host.value = {};
+            fixture.detectChanges();
 
             expect(directive.validate(control)).toBeNull();
         });
 
         it('should handle null input value', () => {
             control = createAbstractControlSpy(null);
-            directive.config = { hasAsciiOnly: true };
+            host.value = { hasAsciiOnly: true };
+            fixture.detectChanges();
 
             expect(directive.validate(control)).toEqual({ alpha: true });
         });
 
         it('should handle undefined input value', () => {
             control = createAbstractControlSpy(undefined);
-            directive.config = { hasAsciiOnly: true };
+            host.value = { hasAsciiOnly: true };
+            fixture.detectChanges();
 
             expect(directive.validate(control)).toEqual({ alpha: true });
         });
 
         it('should handle empty string input value', () => {
             control = createAbstractControlSpy('');
-            directive.config = { hasAsciiOnly: true };
+            host.value = { hasAsciiOnly: true };
+            fixture.detectChanges();
 
             expect(directive.validate(control)).toEqual({ alpha: true });
         });

--- a/src/lib/directives/string/nguard-alpha.directive.ts
+++ b/src/lib/directives/string/nguard-alpha.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 
 // Types
@@ -19,11 +19,11 @@ import { StringValidators } from '../../validators/string.validators';
     standalone: true,
 })
 export class NguardAlphaDirective implements Validator {
-    @Input('nguardAlpha') public config!: CharsetConfig;
+    public readonly config = input<CharsetConfig | undefined>(undefined, { alias: 'nguardAlpha' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        return StringValidators.alpha(this.config?.hasAsciiOnly)(control);
+        return StringValidators.alpha(this.config()?.hasAsciiOnly)(control);
     }
 }

--- a/src/lib/directives/string/nguard-not-regex.directive.ts
+++ b/src/lib/directives/string/nguard-not-regex.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 import { StringValidators } from '../../validators/string.validators';
 
@@ -14,11 +14,11 @@ import { StringValidators } from '../../validators/string.validators';
     standalone: true,
 })
 export class NguardNotRegexDirective implements Validator {
-    @Input('nguardNotRegex') public pattern!: RegExp;
+    public readonly pattern = input.required<RegExp>({ alias: 'nguardNotRegex' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        return StringValidators.notRegex(this.pattern)(control);
+        return StringValidators.notRegex(this.pattern())(control);
     }
 }

--- a/src/lib/directives/string/nguard-regex.directive.ts
+++ b/src/lib/directives/string/nguard-regex.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
 import { StringValidators } from '../../validators/string.validators';
 
@@ -14,11 +14,11 @@ import { StringValidators } from '../../validators/string.validators';
     standalone: true,
 })
 export class NguardRegexDirective implements Validator {
-    @Input('nguardRegex') public pattern!: RegExp;
+    public readonly pattern = input.required<RegExp>({ alias: 'nguardRegex' });
 
     constructor() {}
 
     public validate(control: AbstractControl<any, any>): ValidationErrors | null {
-        return StringValidators.regex(this.pattern)(control);
+        return StringValidators.regex(this.pattern())(control);
     }
 }

--- a/src/lib/utils/test.utils.ts
+++ b/src/lib/utils/test.utils.ts
@@ -1,4 +1,53 @@
+import { Component, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+
+/**
+ * Result of {@link createDirectiveFixture}. Exposes the directive instance, the host
+ * component's fixture (for change detection and DOM access) and the host instance whose
+ * `value` property is bound to the directive's input through the supplied template.
+ */
+export type DirectiveFixture<T, H = TestHostComponent> = {
+    directive: T;
+    fixture: ComponentFixture<H>;
+    host: H;
+};
+
+/**
+ * Generic host component used by {@link createDirectiveFixture}. Exposes a single `value`
+ * property that test templates bind to the directive's input.
+ */
+export class TestHostComponent {
+    public value: unknown = undefined;
+}
+
+/**
+ * Creates a TestBed fixture that hosts the supplied directive on a generic component.
+ * Signal-based inputs (`input()` / `input.required()`) cannot be assigned directly on a
+ * directive instance, so tests must drive them through a host binding. Each spec passes
+ * its own template literal containing the directive's selector bound to `value`.
+ *
+ * @param directiveType The directive class under test.
+ * @param template Inline template applied to the host component, e.g. `<div [nguardAlpha]="value"></div>`.
+ * @returns The directive instance, the host fixture and the host component.
+ */
+export const createDirectiveFixture = <T>(directiveType: Type<T>, template: string): DirectiveFixture<T> => {
+    @Component({
+        imports: [directiveType],
+        standalone: true,
+        template,
+    })
+    class HostComponent extends TestHostComponent {}
+
+    TestBed.configureTestingModule({ imports: [HostComponent] });
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    const directive = fixture.debugElement.query(By.directive(directiveType)).injector.get(directiveType);
+
+    return { directive, fixture, host: fixture.componentInstance };
+};
 
 /**
  * Creates a mock AbstractControl with the specified value

--- a/src/lib/utils/test.utils.ts
+++ b/src/lib/utils/test.utils.ts
@@ -28,11 +28,20 @@ export class TestHostComponent {
  * directive instance, so tests must drive them through a host binding. Each spec passes
  * its own template literal containing the directive's selector bound to `value`.
  *
+ * The optional `initialValue` is assigned to the host before the first change detection
+ * pass so that `input.required<T>()` directives are satisfied at fixture creation time.
+ * Tests can later overwrite `host.value` and call `fixture.detectChanges()` to update.
+ *
  * @param directiveType The directive class under test.
  * @param template Inline template applied to the host component, e.g. `<div [nguardAlpha]="value"></div>`.
+ * @param initialValue Initial value for the host's `value` property. Required for directives with `input.required<T>()`.
  * @returns The directive instance, the host fixture and the host component.
  */
-export const createDirectiveFixture = <T>(directiveType: Type<T>, template: string): DirectiveFixture<T> => {
+export const createDirectiveFixture = <T>(
+    directiveType: Type<T>,
+    template: string,
+    initialValue: unknown = undefined
+): DirectiveFixture<T> => {
     @Component({
         imports: [directiveType],
         standalone: true,
@@ -42,6 +51,7 @@ export const createDirectiveFixture = <T>(directiveType: Type<T>, template: stri
 
     TestBed.configureTestingModule({ imports: [HostComponent] });
     const fixture = TestBed.createComponent(HostComponent);
+    fixture.componentInstance.value = initialValue;
     fixture.detectChanges();
 
     const directive = fixture.debugElement.query(By.directive(directiveType)).injector.get(directiveType);


### PR DESCRIPTION
## Summary

Phase 2 of #12. Converts every directive's `@Input()` decorator to Angular signal-based inputs (`input()` / `input.required()`) and standardizes the input shape across the entire library.

| Category | Directives migrated |
|---|---|
| string | alpha, alphaDash, alphaNum, regex, notRegex |
| number | between, max, min, range |
| multi | confirmed, same, different, gt, gte, lt, lte, requiredIf, startsWith, endsWith, doesntStartWith, doesntEndWith |

## Standardization rule

Every directive's primary input is now **aliased to the selector** and accepts `T \| TConfig` where `T` is the natural shorthand. No more bare `[propertyName]=` variants. The four `gt`/`gte`/`lt`/`lte` directives previously had unaliased `compareFieldKey`; they're now aliased and renamed to `fieldKey` for cross-codebase consistency.

## Phase 4 absorbed

Spec rewrites are inseparable from the directive change (signal inputs are read-only on the directive instance). All 17 existing directive specs are rewritten to use a new `createDirectiveFixture` helper. Phase 4 in the original #12 plan is effectively merged into this PR.

## Other tweaks intrinsic to the rewrite

- `same`/`different` directives no longer use the `MultiValidators.X.apply(this, args)` antipattern (arrow-factory validators don't bind `this`); they now make a direct call.
- Angular peer dependency floor bumped to `>=17.3.0 <23.0.0` (input signals are stable from 17.3; cap covers Angular 22).

## Out of scope (deferred)

- All directives still have empty `constructor() {}` and `validate(control: AbstractControl<any, any>)` — Phase 3.
- Validator-level cleanup (#20 / Phase 5) is a follow-up PR stacked on this one.

## Test plan

- [ ] `npm test` — Firefox launches, all directive specs pass against the new fixture pattern
- [ ] `ng build` — library compiles cleanly
- [ ] No remaining `@Input()` decorator usage in `src/lib/directives/`

Refs #12, depends on no other PR