### PR TITLE
Phase 5 of #12: validator function cleanup (input type guards, hygiene, JSDoc)

### DIFF
--- a/src/lib/validators/multi.validators.ts
+++ b/src/lib/validators/multi.validators.ts
@@ -29,7 +29,7 @@ export namespace MultiValidators {
      * password: new FormControl(''),
      * passwordConfirm: new FormControl('', [NguardValidators.Multi.different('password')])
      * ```
-     * @return {ValidationFn}
+     * @return {ValidatorFn}
      */
     export const different = (fieldKey: string, isStrict: boolean = false): ValidatorFn => {
         return (c: AbstractControl): ValidationErrors | null => {
@@ -52,7 +52,7 @@ export namespace MultiValidators {
      *   NguardValidators.Multi.doesntEndWith('first', 'second', 'third')
      * ])
      * ```
-     * @return {ValidationFn}
+     * @return {ValidatorFn}
      */
     export const doesntEndWith = (...values: primitive[]): ValidatorFn => {
         return (control: AbstractControl): ValidationErrors | null => {
@@ -77,7 +77,7 @@ export namespace MultiValidators {
      *   NguardValidators.Multi.doesntStartWith('first', 'second', 'third')
      * ])
      * ```
-     * @return {ValidationFn}
+     * @return {ValidatorFn}
      */
     export const doesntStartWith = (...values: primitive[]): ValidatorFn => {
         return (control: AbstractControl): ValidationErrors | null => {
@@ -104,7 +104,7 @@ export namespace MultiValidators {
      * ```
      *
      * @param {primitive[]} values A mixed array of primitive values (strings, numbers and boolean)
-     * @return {ValidationFn}
+     * @return {ValidatorFn}
      */
     export const endsWith = (...values: primitive[]): ValidatorFn => {
         return (control: AbstractControl): ValidationErrors | null => {
@@ -253,7 +253,7 @@ export namespace MultiValidators {
      *
      * ```
      * new FormControl('', [
-     *   NguardValidators.String.requiredIf('anotherField', 'another field value', true)
+     *   NguardValidators.Multi.requiredIf('anotherField', 'another field value', true)
      * ])
      * ```
      *
@@ -281,7 +281,7 @@ export namespace MultiValidators {
      * password: new FormControl(''),
      * passwordConfirm: new FormControl('', [NguardValidators.Multi.same('password')])
      * ```
-     * @return {ValidationFn}
+     * @return {ValidatorFn}
      */
     export const same = (fieldKey: string, isStrict: boolean = false): ValidatorFn => {
         return (c: AbstractControl): ValidationErrors | null => {
@@ -306,7 +306,7 @@ export namespace MultiValidators {
      * ```
      *
      * @param {primitive[]} values A mixed array of primitive values (strings, numbers and boolean)
-     * @return {ValidationFn}
+     * @return {ValidatorFn}
      */
     export const startsWith = (...values: primitive[]): ValidatorFn => {
         return (control: AbstractControl): ValidationErrors | null => {

--- a/src/lib/validators/multi.validators.ts
+++ b/src/lib/validators/multi.validators.ts
@@ -22,7 +22,7 @@ export namespace MultiValidators {
     };
 
     /**
-     * Validate that an attribute is different to another one with the specified compareFieldKey
+     * Validate that an attribute is different to another one with the specified fieldKey
      * The performed check is case sensitive for strings
      *
      * ```
@@ -31,9 +31,9 @@ export namespace MultiValidators {
      * ```
      * @return {ValidationFn}
      */
-    export const different = (compareFieldKey: string, isStrict: boolean = false): ValidatorFn => {
+    export const different = (fieldKey: string, isStrict: boolean = false): ValidatorFn => {
         return (c: AbstractControl): ValidationErrors | null => {
-            if (equalityCheck(c.value, c.parent?.get(compareFieldKey)?.value, isStrict)) {
+            if (equalityCheck(c.value, c.parent?.get(fieldKey)?.value, isStrict)) {
                 return {
                     different: true,
                 };
@@ -133,12 +133,12 @@ export namespace MultiValidators {
      * ])
      * ```
      *
-     * @param {string} compareFieldKey
+     * @param {string} fieldKey
      * @returns {ValidatorFn}
      */
-    export const greaterThan = (compareFieldKey: string): ValidatorFn => {
+    export const greaterThan = (fieldKey: string): ValidatorFn => {
         return (c: AbstractControl) => {
-            const [value1, value2] = [c.value, c.parent?.get(compareFieldKey)?.value];
+            const [value1, value2] = [c.value, c.parent?.get(fieldKey)?.value];
 
             if (!haveSameType(value1, value2)) {
                 return { greaterThan: true };
@@ -164,12 +164,12 @@ export namespace MultiValidators {
      * ])
      * ```
      *
-     * @param {string} compareFieldKey
+     * @param {string} fieldKey
      * @returns {ValidatorFn}
      */
-    export const greaterThanOrEqual = (compareFieldKey: string): ValidatorFn => {
+    export const greaterThanOrEqual = (fieldKey: string): ValidatorFn => {
         return (c: AbstractControl) => {
-            const [value1, value2] = [c.value, c.parent?.get(compareFieldKey)?.value];
+            const [value1, value2] = [c.value, c.parent?.get(fieldKey)?.value];
 
             if (!haveSameType(value1, value2)) {
                 return { greaterThanOrEqual: true };
@@ -195,12 +195,12 @@ export namespace MultiValidators {
      * ])
      * ```
      *
-     * @param {string} compareFieldKey
+     * @param {string} fieldKey
      * @returns {ValidatorFn}
      */
-    export const lesserThan = (compareFieldKey: string): ValidatorFn => {
+    export const lesserThan = (fieldKey: string): ValidatorFn => {
         return (c: AbstractControl) => {
-            const [value1, value2] = [c.value, c.parent?.get(compareFieldKey)?.value];
+            const [value1, value2] = [c.value, c.parent?.get(fieldKey)?.value];
 
             if (!haveSameType(value1, value2)) {
                 return { lesserThan: true };
@@ -226,12 +226,12 @@ export namespace MultiValidators {
      * ])
      * ```
      *
-     * @param {string} compareFieldKey
+     * @param {string} fieldKey
      * @returns {ValidatorFn}
      */
-    export const lesserThanOrEqual = (compareFieldKey: string): ValidatorFn => {
+    export const lesserThanOrEqual = (fieldKey: string): ValidatorFn => {
         return (c: AbstractControl) => {
-            const [value1, value2] = [c.value, c.parent?.get(compareFieldKey)?.value];
+            const [value1, value2] = [c.value, c.parent?.get(fieldKey)?.value];
 
             if (!haveSameType(value1, value2)) {
                 return { lesserThanOrEqual: true };
@@ -274,7 +274,7 @@ export namespace MultiValidators {
     };
 
     /**
-     * Validate that an attribute is equal to another one with the specified compareFieldKey
+     * Validate that an attribute is equal to another one with the specified fieldKey
      * The performed check is case sensitive
      *
      * ```
@@ -283,9 +283,9 @@ export namespace MultiValidators {
      * ```
      * @return {ValidationFn}
      */
-    export const same = (compareFieldKey: string, isStrict: boolean = false): ValidatorFn => {
+    export const same = (fieldKey: string, isStrict: boolean = false): ValidatorFn => {
         return (c: AbstractControl): ValidationErrors | null => {
-            if (equalityCheck(c.value, c.parent?.get(compareFieldKey)?.value, isStrict)) {
+            if (equalityCheck(c.value, c.parent?.get(fieldKey)?.value, isStrict)) {
                 return null;
             }
 

--- a/src/lib/validators/number.validators.ts
+++ b/src/lib/validators/number.validators.ts
@@ -144,16 +144,11 @@ export namespace NumberValidators {
             if (minVal > maxVal) {
                 throw new RangeValidatorErrors.MinGreaterThanMax();
             }
-
-            const value = +c.value;
-
-            if (isNaN(value) || value < minVal || value > maxVal) {
-                return {
-                    range: true,
-                };
+            if (!isNumeric(c.value)) {
+                return { range: true };
             }
-
-            return null;
+            const value = Number(c.value);
+            return value >= minVal && value <= maxVal ? null : { range: true };
         };
     };
 }

--- a/src/lib/validators/string.validators.ts
+++ b/src/lib/validators/string.validators.ts
@@ -14,7 +14,7 @@ export namespace StringValidators {
      * ])
      * ```
      * @param {boolean} hasAsciiOnly If true, limits characters to ASCII chars (a-z and A-Z)
-     * @return {ValidationFn}
+     * @return {ValidatorFn}
      */
     export const alpha = (hasAsciiOnly: boolean = false) => {
         return (c: AbstractControl): ValidationErrors | null => {
@@ -38,7 +38,7 @@ export namespace StringValidators {
      * ])
      * ```
      * @param {boolean} hasAsciiOnly If true, limits characters to ASCII chars (a-z and A-Z)
-     * @return {ValidationFn}
+     * @return {ValidatorFn}
      */
     export const alphaDash = (hasAsciiOnly: boolean = false) => {
         return (c: AbstractControl): ValidationErrors | null => {
@@ -62,7 +62,7 @@ export namespace StringValidators {
      * ])
      * ```
      * @param {boolean} hasAsciiOnly If true, limits characters to ASCII chars (a-z and A-Z)
-     * @return {ValidationFn}
+     * @return {ValidatorFn}
      */
     export const alphaNum = (hasAsciiOnly: boolean = false) => {
         return (c: AbstractControl): ValidationErrors | null => {

--- a/src/lib/validators/string.validators.ts
+++ b/src/lib/validators/string.validators.ts
@@ -1,6 +1,6 @@
 import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
-const isString = (value: any) => typeof value === 'string';
+const isString = (value: unknown): boolean => typeof value === 'string';
 
 export namespace StringValidators {
     /**

--- a/src/lib/validators/string.validators.ts
+++ b/src/lib/validators/string.validators.ts
@@ -17,7 +17,10 @@ export namespace StringValidators {
      * @return {ValidationFn}
      */
     export const alpha = (hasAsciiOnly: boolean = false) => {
-        return (c: AbstractControl) => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            if (!isString(c.value) || c.value.length === 0) {
+                return { alpha: true };
+            }
             const regEx: RegExp = hasAsciiOnly ? /^[a-zA-Z]+$/u : /^[\p{L}\p{M}]+$/u;
 
             return regEx.test(c.value) ? null : { alpha: true };
@@ -38,7 +41,10 @@ export namespace StringValidators {
      * @return {ValidationFn}
      */
     export const alphaDash = (hasAsciiOnly: boolean = false) => {
-        return (c: AbstractControl) => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            if (!isString(c.value) || c.value.length === 0) {
+                return { alphaDash: true };
+            }
             const regEx: RegExp = hasAsciiOnly ? /^[a-zA-Z0-9_-]+$/u : /^[\p{L}\p{M}\p{N}_-]+$/u;
 
             return regEx.test(c.value) ? null : { alphaDash: true };
@@ -59,7 +65,10 @@ export namespace StringValidators {
      * @return {ValidationFn}
      */
     export const alphaNum = (hasAsciiOnly: boolean = false) => {
-        return (c: AbstractControl) => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            if (!isString(c.value) || c.value.length === 0) {
+                return { alphaNum: true };
+            }
             const regEx: RegExp = hasAsciiOnly ? /^[a-zA-Z0-9]+$/u : /^[\p{L}\p{M}\p{N}]+$/u;
 
             return regEx.test(c.value) ? null : { alphaNum: true };
@@ -82,8 +91,13 @@ export namespace StringValidators {
      * ```
      * @return {ValidationErrors | null}
      */
-    // eslint-disable-next-line no-control-regex
-    export const ascii = (c: AbstractControl) => (/^[\x09\x0A\x0D\x20-\x7E]+$/.test(c.value) ? null : { ascii: true });
+    export const ascii = (c: AbstractControl): ValidationErrors | null => {
+        if (!isString(c.value) || c.value.length === 0) {
+            return { ascii: true };
+        }
+        // eslint-disable-next-line no-control-regex
+        return /^[\x09\x0A\x0D\x20-\x7E]+$/.test(c.value) ? null : { ascii: true };
+    };
 
     /**
      * The field under validation must be a valid email address (RFC 5322 compliant)
@@ -134,7 +148,7 @@ export namespace StringValidators {
      * @return {ValidationErrors | null}
      */
     export const lowercase = (c: AbstractControl): ValidationErrors | null =>
-        isString(c.value) && c.value.toLowerCase() === c.value ? null : { lowercase: true };
+        isString(c.value) && c.value.length > 0 && c.value.toLowerCase() === c.value ? null : { lowercase: true };
 
     /**
      * The field under validation must not be empty or contain only whitespace
@@ -199,7 +213,7 @@ export namespace StringValidators {
      * @return {ValidationErrors | null}
      */
     export const uppercase = (c: AbstractControl<string>): ValidationErrors | null =>
-        isString(c.value) && c.value.toUpperCase() === c.value ? null : { uppercase: true };
+        isString(c.value) && c.value.length > 0 && c.value.toUpperCase() === c.value ? null : { uppercase: true };
 
     /**
      * The field under validation must be a valid URL as...


### PR DESCRIPTION
## Summary

Phase 5 of #12. Stacked on top of #21 (Phase 2). Five atomic commits:

| Commit | What |
|---|---|
| `c486238` | `refactor`: `any` → `unknown` in the `isString` helper |
| `bf380c1` | `fix`: regex-based string validators reject non-string and empty inputs (alpha, alphaDash, alphaNum, ascii); lowercase/uppercase reject empty |
| `e927e60` | `fix`: `range` uses `isNumeric` guard instead of `+c.value` coercion |
| `0f755f8` | `refactor`: rename `compareFieldKey` parameter → `fieldKey` in `multi.validators.ts` |
| `9578678` | `docs`: fix JSDoc typos (`{ValidationFn}` → `{ValidatorFn}`) and wrong namespace reference (`String.requiredIf` → `Multi.requiredIf`) |

## Why this lands now (out of declared phase order)

Phase 2 (#21) made the test suite actually runnable — #17 fixed the test infrastructure. Once tests run, **27 pre-existing latent failures** become visible in the validator specs at `string.validators.spec.ts:675-870` and `number.validators.spec.ts:392-411`. These were always failing but invisible because Chrome 121 wouldn't launch.

`git diff develop..feature/19 -- src/lib/validators/` shows zero changes to validator code on the Phase 2 branch — the failures are not Phase 2 regressions. Fixing them now keeps CI green going forward instead of letting noise mask future real regressions.

Root cause: `RegExp.prototype.test` coerces non-strings via `String()`, so `null` becomes `'null'` and matches `[a-zA-Z]+`. `+null` and `+''` both equal `0`, so `range(0, 10)` accepted them. `''.toLowerCase() === ''` is trivially true.

## Test plan

- [ ] `npm test` — all 427 specs pass (was 27 failing on `feature/19` alone)
- [ ] `ng build` — library compiles cleanly
- [ ] No `compareFieldKey` references remain anywhere in the codebase

## Merge order

1. Merge #21 → develop first
2. Rebase / change-base #20 onto develop
3. Merge #20 → develop

Closes #20, refs #12