### PR TITLE
Phase 3 of #12: directive code hygiene cleanup

### DIFF
--- a/src/lib/directives/cross-field/nguard-confirmed.directive.ts
+++ b/src/lib/directives/cross-field/nguard-confirmed.directive.ts
@@ -16,9 +16,7 @@ import { CrossFieldValidators } from '../../validators/cross-field.validators';
 export class NguardConfirmedDirective implements Validator {
     public readonly fieldKey = input.required<string>({ alias: 'nguardConfirmed' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return CrossFieldValidators.confirmed(this.fieldKey())(control);
     }
 }

--- a/src/lib/directives/cross-field/nguard-different.directive.ts
+++ b/src/lib/directives/cross-field/nguard-different.directive.ts
@@ -21,9 +21,7 @@ import { CrossFieldValidators } from '../../validators/cross-field.validators';
 export class NguardDifferentDirective implements Validator {
     public readonly config = input.required<string | FieldComparisonConfig>({ alias: 'nguardDifferent' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         const cfg = this.config();
         const [fieldKey, isStrict]: [string, boolean | undefined] =
             typeof cfg === 'string' ? [cfg, undefined] : [cfg.fieldKey, cfg.isStrict];

--- a/src/lib/directives/cross-field/nguard-required-if.directive.ts
+++ b/src/lib/directives/cross-field/nguard-required-if.directive.ts
@@ -17,9 +17,7 @@ import { FieldConditionConfig } from '../../types/field-condition-config.type';
 export class NguardRequiredIfDirective implements Validator {
     public readonly config = input.required<string | FieldConditionConfig>({ alias: 'nguardRequiredIf' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         const cfg = this.config();
         const fieldKey = typeof cfg === 'string' ? cfg : cfg.fieldKey;
         const isStrict = typeof cfg === 'string' ? undefined : cfg.isStrict;

--- a/src/lib/directives/cross-field/nguard-same.directive.ts
+++ b/src/lib/directives/cross-field/nguard-same.directive.ts
@@ -17,9 +17,7 @@ import { FieldComparisonConfig } from '../../types/field-comparison-config.type'
 export class NguardSameDirective implements Validator {
     public readonly config = input.required<string | FieldComparisonConfig>({ alias: 'nguardSame' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         const cfg = this.config();
         const [fieldKey, isStrict]: [string, boolean | undefined] =
             typeof cfg === 'string' ? [cfg, undefined] : [cfg.fieldKey, cfg.isStrict];

--- a/src/lib/directives/number/nguard-between.directive.ts
+++ b/src/lib/directives/number/nguard-between.directive.ts
@@ -16,9 +16,7 @@ import { NumberValidators } from '../../validators/number.validators';
 export class NguardBetweenDirective implements Validator {
     public readonly values = input.required<[number, number]>({ alias: 'nguardBetween' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return NumberValidators.between(...this.values())(control);
     }
 }

--- a/src/lib/directives/number/nguard-greater-than-or-equal.directive.ts
+++ b/src/lib/directives/number/nguard-greater-than-or-equal.directive.ts
@@ -16,9 +16,7 @@ import { NumberValidators } from '../../validators/number.validators';
 export class NguardGreaterThanOrEqualDirective implements Validator {
     public readonly fieldKey = input.required<string>({ alias: 'nguardGreaterThanOrEqual' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return NumberValidators.greaterThanOrEqual(this.fieldKey())(control);
     }
 }

--- a/src/lib/directives/number/nguard-greater-than.directive.ts
+++ b/src/lib/directives/number/nguard-greater-than.directive.ts
@@ -16,9 +16,7 @@ import { NumberValidators } from '../../validators/number.validators';
 export class NguardGreaterThanDirective implements Validator {
     public readonly fieldKey = input.required<string>({ alias: 'nguardGreaterThan' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return NumberValidators.greaterThan(this.fieldKey())(control);
     }
 }

--- a/src/lib/directives/number/nguard-integer.directive.ts
+++ b/src/lib/directives/number/nguard-integer.directive.ts
@@ -14,9 +14,7 @@ import { NumberValidators } from '../../validators/number.validators';
     standalone: true,
 })
 export class NguardIntegerDirective implements Validator {
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return NumberValidators.integer(control);
     }
 }

--- a/src/lib/directives/number/nguard-lesser-than-or-equal.directive.ts
+++ b/src/lib/directives/number/nguard-lesser-than-or-equal.directive.ts
@@ -16,9 +16,7 @@ import { NumberValidators } from '../../validators/number.validators';
 export class NguardLesserThanOrEqualDirective implements Validator {
     public readonly fieldKey = input.required<string>({ alias: 'nguardLesserThanOrEqual' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return NumberValidators.lesserThanOrEqual(this.fieldKey())(control);
     }
 }

--- a/src/lib/directives/number/nguard-lesser-than.directive.ts
+++ b/src/lib/directives/number/nguard-lesser-than.directive.ts
@@ -16,9 +16,7 @@ import { NumberValidators } from '../../validators/number.validators';
 export class NguardLesserThanDirective implements Validator {
     public readonly fieldKey = input.required<string>({ alias: 'nguardLesserThan' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return NumberValidators.lesserThan(this.fieldKey())(control);
     }
 }

--- a/src/lib/directives/number/nguard-max.directive.ts
+++ b/src/lib/directives/number/nguard-max.directive.ts
@@ -16,9 +16,7 @@ import { NumberValidators } from '../../validators/number.validators';
 export class NguardMaxDirective implements Validator {
     public readonly maxVal = input.required<number>({ alias: 'nguardMax' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return NumberValidators.max(this.maxVal())(control);
     }
 }

--- a/src/lib/directives/number/nguard-min.directive.ts
+++ b/src/lib/directives/number/nguard-min.directive.ts
@@ -16,9 +16,7 @@ import { NumberValidators } from '../../validators/number.validators';
 export class NguardMinDirective implements Validator {
     public readonly minVal = input.required<number>({ alias: 'nguardMin' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return NumberValidators.min(this.minVal())(control);
     }
 }

--- a/src/lib/directives/number/nguard-negative.directive.ts
+++ b/src/lib/directives/number/nguard-negative.directive.ts
@@ -14,9 +14,7 @@ import { NumberValidators } from '../../validators/number.validators';
     standalone: true,
 })
 export class NguardNegativeDirective implements Validator {
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return NumberValidators.negative(control);
     }
 }

--- a/src/lib/directives/number/nguard-numeric.directive.ts
+++ b/src/lib/directives/number/nguard-numeric.directive.ts
@@ -14,9 +14,7 @@ import { NumberValidators } from '../../validators/number.validators';
     standalone: true,
 })
 export class NguardNumericDirective implements Validator {
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return NumberValidators.numeric(control);
     }
 }

--- a/src/lib/directives/number/nguard-positive.directive.ts
+++ b/src/lib/directives/number/nguard-positive.directive.ts
@@ -14,9 +14,7 @@ import { NumberValidators } from '../../validators/number.validators';
     standalone: true,
 })
 export class NguardPositiveDirective implements Validator {
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return NumberValidators.positive(control);
     }
 }

--- a/src/lib/directives/string/nguard-alpha-dash.directive.ts
+++ b/src/lib/directives/string/nguard-alpha-dash.directive.ts
@@ -21,9 +21,7 @@ import { StringValidators } from '../../validators/string.validators';
 export class NguardAlphaDashDirective implements Validator {
     public readonly config = input<CharsetConfig | undefined>(undefined, { alias: 'nguardAlphaDash' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.alphaDash(this.config()?.hasAsciiOnly)(control);
     }
 }

--- a/src/lib/directives/string/nguard-alpha-num.directive.ts
+++ b/src/lib/directives/string/nguard-alpha-num.directive.ts
@@ -21,9 +21,7 @@ import { StringValidators } from '../../validators/string.validators';
 export class NguardAlphaNumDirective implements Validator {
     public readonly config = input<CharsetConfig | undefined>(undefined, { alias: 'nguardAlphaNum' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.alphaNum(this.config()?.hasAsciiOnly)(control);
     }
 }

--- a/src/lib/directives/string/nguard-alpha.directive.ts
+++ b/src/lib/directives/string/nguard-alpha.directive.ts
@@ -21,9 +21,7 @@ import { StringValidators } from '../../validators/string.validators';
 export class NguardAlphaDirective implements Validator {
     public readonly config = input<CharsetConfig | undefined>(undefined, { alias: 'nguardAlpha' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.alpha(this.config()?.hasAsciiOnly)(control);
     }
 }

--- a/src/lib/directives/string/nguard-ascii.directive.ts
+++ b/src/lib/directives/string/nguard-ascii.directive.ts
@@ -16,9 +16,7 @@ import { StringValidators } from '../../validators/string.validators';
     standalone: true,
 })
 export class NguardAsciiDirective implements Validator {
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.ascii(control);
     }
 }

--- a/src/lib/directives/string/nguard-doesnt-end-with.directive.ts
+++ b/src/lib/directives/string/nguard-doesnt-end-with.directive.ts
@@ -21,9 +21,7 @@ import { StringValidators } from '../../validators/string.validators';
 export class NguardDoesntEndWithDirective implements Validator {
     public readonly values = input.required<primitive | primitive[]>({ alias: 'nguardDoesntEndWith' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         const raw = this.values();
         const values = Array.isArray(raw) ? raw : [raw];
         return StringValidators.doesntEndWith(...values)(control);

--- a/src/lib/directives/string/nguard-doesnt-start-with.directive.ts
+++ b/src/lib/directives/string/nguard-doesnt-start-with.directive.ts
@@ -21,9 +21,7 @@ import { StringValidators } from '../../validators/string.validators';
 export class NguardDoesntStartWithDirective implements Validator {
     public readonly values = input.required<primitive | primitive[]>({ alias: 'nguardDoesntStartWith' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         const raw = this.values();
         const values = Array.isArray(raw) ? raw : [raw];
         return StringValidators.doesntStartWith(...values)(control);

--- a/src/lib/directives/string/nguard-email.directive.ts
+++ b/src/lib/directives/string/nguard-email.directive.ts
@@ -14,9 +14,7 @@ import { StringValidators } from '../../validators/string.validators';
     standalone: true,
 })
 export class NguardEmailDirective implements Validator {
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.email(control);
     }
 }

--- a/src/lib/directives/string/nguard-ends-with.directive.ts
+++ b/src/lib/directives/string/nguard-ends-with.directive.ts
@@ -21,9 +21,7 @@ import { StringValidators } from '../../validators/string.validators';
 export class NguardEndsWithDirective implements Validator {
     public readonly values = input.required<primitive | primitive[]>({ alias: 'nguardEndsWith' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         const raw = this.values();
         const values = Array.isArray(raw) ? raw : [raw];
         return StringValidators.endsWith(...values)(control);

--- a/src/lib/directives/string/nguard-json.directive.ts
+++ b/src/lib/directives/string/nguard-json.directive.ts
@@ -14,9 +14,7 @@ import { StringValidators } from '../../validators/string.validators';
     standalone: true,
 })
 export class NguardJsonDirective implements Validator {
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.json(control);
     }
 }

--- a/src/lib/directives/string/nguard-longer-or-equal-to.directive.ts
+++ b/src/lib/directives/string/nguard-longer-or-equal-to.directive.ts
@@ -16,9 +16,7 @@ import { StringValidators } from '../../validators/string.validators';
 export class NguardLongerOrEqualToDirective implements Validator {
     public readonly fieldKey = input.required<string>({ alias: 'nguardLongerOrEqualTo' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.longerOrEqualTo(this.fieldKey())(control);
     }
 }

--- a/src/lib/directives/string/nguard-longer-than.directive.ts
+++ b/src/lib/directives/string/nguard-longer-than.directive.ts
@@ -16,9 +16,7 @@ import { StringValidators } from '../../validators/string.validators';
 export class NguardLongerThanDirective implements Validator {
     public readonly fieldKey = input.required<string>({ alias: 'nguardLongerThan' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.longerThan(this.fieldKey())(control);
     }
 }

--- a/src/lib/directives/string/nguard-lowercase.directive.ts
+++ b/src/lib/directives/string/nguard-lowercase.directive.ts
@@ -16,9 +16,7 @@ import { StringValidators } from '../../validators/string.validators';
     standalone: true,
 })
 export class NguardLowercaseDirective implements Validator {
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.lowercase(control);
     }
 }

--- a/src/lib/directives/string/nguard-not-blank.directive.ts
+++ b/src/lib/directives/string/nguard-not-blank.directive.ts
@@ -14,9 +14,7 @@ import { StringValidators } from '../../validators/string.validators';
     standalone: true,
 })
 export class NguardNotBlankDirective implements Validator {
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.notBlank(control);
     }
 }

--- a/src/lib/directives/string/nguard-not-regex.directive.ts
+++ b/src/lib/directives/string/nguard-not-regex.directive.ts
@@ -16,9 +16,7 @@ import { StringValidators } from '../../validators/string.validators';
 export class NguardNotRegexDirective implements Validator {
     public readonly pattern = input.required<RegExp>({ alias: 'nguardNotRegex' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.notRegex(this.pattern())(control);
     }
 }

--- a/src/lib/directives/string/nguard-regex.directive.ts
+++ b/src/lib/directives/string/nguard-regex.directive.ts
@@ -16,9 +16,7 @@ import { StringValidators } from '../../validators/string.validators';
 export class NguardRegexDirective implements Validator {
     public readonly pattern = input.required<RegExp>({ alias: 'nguardRegex' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.regex(this.pattern())(control);
     }
 }

--- a/src/lib/directives/string/nguard-shorter-or-equal-to.directive.ts
+++ b/src/lib/directives/string/nguard-shorter-or-equal-to.directive.ts
@@ -16,9 +16,7 @@ import { StringValidators } from '../../validators/string.validators';
 export class NguardShorterOrEqualToDirective implements Validator {
     public readonly fieldKey = input.required<string>({ alias: 'nguardShorterOrEqualTo' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.shorterOrEqualTo(this.fieldKey())(control);
     }
 }

--- a/src/lib/directives/string/nguard-shorter-than.directive.ts
+++ b/src/lib/directives/string/nguard-shorter-than.directive.ts
@@ -16,9 +16,7 @@ import { StringValidators } from '../../validators/string.validators';
 export class NguardShorterThanDirective implements Validator {
     public readonly fieldKey = input.required<string>({ alias: 'nguardShorterThan' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.shorterThan(this.fieldKey())(control);
     }
 }

--- a/src/lib/directives/string/nguard-starts-with.directive.ts
+++ b/src/lib/directives/string/nguard-starts-with.directive.ts
@@ -21,9 +21,7 @@ import { StringValidators } from '../../validators/string.validators';
 export class NguardStartsWithDirective implements Validator {
     public readonly values = input.required<primitive | primitive[]>({ alias: 'nguardStartsWith' });
 
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         const raw = this.values();
         const values = Array.isArray(raw) ? raw : [raw];
         return StringValidators.startsWith(...values)(control);

--- a/src/lib/directives/string/nguard-uppercase.directive.ts
+++ b/src/lib/directives/string/nguard-uppercase.directive.ts
@@ -16,9 +16,7 @@ import { StringValidators } from '../../validators/string.validators';
     standalone: true,
 })
 export class NguardUppercaseDirective implements Validator {
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.uppercase(control);
     }
 }

--- a/src/lib/directives/string/nguard-url.directive.ts
+++ b/src/lib/directives/string/nguard-url.directive.ts
@@ -14,9 +14,7 @@ import { StringValidators } from '../../validators/string.validators';
     standalone: true,
 })
 export class NguardUrlDirective implements Validator {
-    constructor() {}
-
-    public validate(control: AbstractControl<any, any>): ValidationErrors | null {
+    public validate(control: AbstractControl): ValidationErrors | null {
         return StringValidators.url(control);
     }
 }

--- a/src/lib/utils/test.utils.ts
+++ b/src/lib/utils/test.utils.ts
@@ -92,8 +92,8 @@ export const createEmptyStringControlSpy = () => createAbstractControlSpy('');
  * @returns A Jasmine spy object mimicking AbstractControl with parent FormGroup
  */
 export const createAbstractControlSpyWithSibling = (
-    field1Value: any,
-    field2Value: any
+    field1Value: unknown,
+    field2Value: unknown
 ): jasmine.SpyObj<AbstractControl> => {
     const parent = jasmine.createSpyObj('FormGroup', ['get']);
     const control1 = jasmine.createSpyObj('FormControl', [], { value: field1Value, parent });
@@ -109,7 +109,7 @@ export const createAbstractControlSpyWithSibling = (
  * @param field1Value The value of the main control
  * @returns A Jasmine spy object mimicking AbstractControl with null sibling
  */
-export const createControlSpyWithNullSibling = (field1Value: any): jasmine.SpyObj<AbstractControl> =>
+export const createControlSpyWithNullSibling = (field1Value: unknown): jasmine.SpyObj<AbstractControl> =>
     createAbstractControlSpyWithSibling(field1Value, null);
 
 /**
@@ -117,7 +117,7 @@ export const createControlSpyWithNullSibling = (field1Value: any): jasmine.SpyOb
  * @param field1Value The value of the main control
  * @returns A Jasmine spy object mimicking AbstractControl with undefined sibling
  */
-export const createControlSpyWithUndefinedSibling = (field1Value: any): jasmine.SpyObj<AbstractControl> =>
+export const createControlSpyWithUndefinedSibling = (field1Value: unknown): jasmine.SpyObj<AbstractControl> =>
     createAbstractControlSpyWithSibling(field1Value, undefined);
 
 /**


### PR DESCRIPTION
## Summary

Final phase of #12. One mechanical sweep eliminating all remaining hygiene debt.

| Change | Count |
|---|---|
| Drop empty `constructor() {}` from directives | 35 |
| `validate(control: AbstractControl<any, any>)` → `validate(control: AbstractControl)` | 35 |
| Test util signatures `any` → `unknown` (`field1Value`, `field2Value`) | 4 |

Net: −109 / +39 lines. No behavior change.

After this lands, `grep -rn ": any\b\|<any\b" src/` returns nothing — the workspace no-`any` rule holds across the entire codebase.

## Test plan

- [x] `npm test` — all specs green (no behavior change)
- [x] `ng build` — library compiles cleanly
- [x] `grep -rn "constructor() {}\|AbstractControl<any" src/` returns nothing
- [x] `grep -rn ": any\b\|<any\b" src/` returns nothing

Closes #25, refs #12