### PR TITLE
feat: v0.3.0 Numeric Power — 8 number validators

### DIFF
--- a/src/lib/directives/number/nguard-decimal.directive.spec.ts
+++ b/src/lib/directives/number/nguard-decimal.directive.spec.ts
@@ -1,0 +1,51 @@
+import { ComponentFixture } from '@angular/core/testing';
+import { AbstractControl } from '@angular/forms';
+import { NguardDecimalDirective } from './nguard-decimal.directive';
+import { createAbstractControlSpy, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
+
+describe('NguardDecimalDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardDecimalDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
+
+    beforeEach(() => {
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardDecimalDirective,
+            '<div [nguardDecimal]="$any(value)"></div>',
+            2
+        ));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate exact decimal places', () => {
+        control = createAbstractControlSpy('1.23');
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail when too few decimal places', () => {
+        control = createAbstractControlSpy('1.2');
+
+        expect(directive.validate(control)).toEqual({ decimal: true });
+    });
+
+    it('should validate within a range when given a tuple', () => {
+        host.value = [1, 3];
+        fixture.detectChanges();
+        control = createAbstractControlSpy('1.23');
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail outside the range', () => {
+        host.value = [1, 3];
+        fixture.detectChanges();
+        control = createAbstractControlSpy('1.2345');
+
+        expect(directive.validate(control)).toEqual({ decimal: true });
+    });
+});

--- a/src/lib/directives/number/nguard-decimal.directive.ts
+++ b/src/lib/directives/number/nguard-decimal.directive.ts
@@ -1,0 +1,26 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { NumberValidators } from '../../validators/number.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardDecimalDirective,
+        },
+    ],
+    selector: '[nguardDecimal]',
+    standalone: true,
+})
+export class NguardDecimalDirective implements Validator {
+    public readonly places = input.required<number | [number, number]>({ alias: 'nguardDecimal' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        const v = this.places();
+        if (Array.isArray(v)) {
+            return NumberValidators.decimal(v[0], v[1])(control);
+        }
+        return NumberValidators.decimal(v)(control);
+    }
+}

--- a/src/lib/directives/number/nguard-digits-between.directive.spec.ts
+++ b/src/lib/directives/number/nguard-digits-between.directive.spec.ts
@@ -1,0 +1,44 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardDigitsBetweenDirective } from './nguard-digits-between.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardDigitsBetweenDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardDigitsBetweenDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(
+            NguardDigitsBetweenDirective,
+            '<div [nguardDigitsBetween]="$any(value)"></div>',
+            [3, 5]
+        ));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate at the lower bound', () => {
+        control = createAbstractControlSpy(123);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should validate at the upper bound', () => {
+        control = createAbstractControlSpy(12345);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail below the lower bound', () => {
+        control = createAbstractControlSpy(12);
+
+        expect(directive.validate(control)).toEqual({ digitsBetween: true });
+    });
+
+    it('should fail above the upper bound', () => {
+        control = createAbstractControlSpy(123456);
+
+        expect(directive.validate(control)).toEqual({ digitsBetween: true });
+    });
+});

--- a/src/lib/directives/number/nguard-digits-between.directive.ts
+++ b/src/lib/directives/number/nguard-digits-between.directive.ts
@@ -1,0 +1,22 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { NumberValidators } from '../../validators/number.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardDigitsBetweenDirective,
+        },
+    ],
+    selector: '[nguardDigitsBetween]',
+    standalone: true,
+})
+export class NguardDigitsBetweenDirective implements Validator {
+    public readonly values = input.required<[number, number]>({ alias: 'nguardDigitsBetween' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return NumberValidators.digitsBetween(...this.values())(control);
+    }
+}

--- a/src/lib/directives/number/nguard-digits.directive.spec.ts
+++ b/src/lib/directives/number/nguard-digits.directive.spec.ts
@@ -1,0 +1,34 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardDigitsDirective } from './nguard-digits.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardDigitsDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardDigitsDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(NguardDigitsDirective, '<div [nguardDigits]="$any(value)"></div>', 4));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate a 4-digit number', () => {
+        control = createAbstractControlSpy(1234);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail on a 3-digit number', () => {
+        control = createAbstractControlSpy(123);
+
+        expect(directive.validate(control)).toEqual({ digits: true });
+    });
+
+    it('should fail on a non-integer value', () => {
+        control = createAbstractControlSpy(12.34);
+
+        expect(directive.validate(control)).toEqual({ digits: true });
+    });
+});

--- a/src/lib/directives/number/nguard-digits.directive.ts
+++ b/src/lib/directives/number/nguard-digits.directive.ts
@@ -1,0 +1,22 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { NumberValidators } from '../../validators/number.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardDigitsDirective,
+        },
+    ],
+    selector: '[nguardDigits]',
+    standalone: true,
+})
+export class NguardDigitsDirective implements Validator {
+    public readonly digits = input.required<number>({ alias: 'nguardDigits' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return NumberValidators.digits(this.digits())(control);
+    }
+}

--- a/src/lib/directives/number/nguard-even.directive.spec.ts
+++ b/src/lib/directives/number/nguard-even.directive.spec.ts
@@ -1,0 +1,34 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardEvenDirective } from './nguard-even.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardEvenDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardEvenDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(NguardEvenDirective, '<div nguardEven></div>'));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate an even integer', () => {
+        control = createAbstractControlSpy(4);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail on an odd integer', () => {
+        control = createAbstractControlSpy(3);
+
+        expect(directive.validate(control)).toEqual({ even: true });
+    });
+
+    it('should fail on a non-integer', () => {
+        control = createAbstractControlSpy(2.5);
+
+        expect(directive.validate(control)).toEqual({ even: true });
+    });
+});

--- a/src/lib/directives/number/nguard-even.directive.ts
+++ b/src/lib/directives/number/nguard-even.directive.ts
@@ -1,0 +1,20 @@
+import { Directive } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { NumberValidators } from '../../validators/number.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardEvenDirective,
+        },
+    ],
+    selector: '[nguardEven]',
+    standalone: true,
+})
+export class NguardEvenDirective implements Validator {
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return NumberValidators.even(control);
+    }
+}

--- a/src/lib/directives/number/nguard-max-digits.directive.spec.ts
+++ b/src/lib/directives/number/nguard-max-digits.directive.spec.ts
@@ -1,0 +1,38 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardMaxDigitsDirective } from './nguard-max-digits.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardMaxDigitsDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardMaxDigitsDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(
+            NguardMaxDigitsDirective,
+            '<div [nguardMaxDigits]="$any(value)"></div>',
+            5
+        ));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate when digit count is at the maximum', () => {
+        control = createAbstractControlSpy(12345);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should validate when digit count is below the maximum', () => {
+        control = createAbstractControlSpy(123);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail when digit count exceeds the maximum', () => {
+        control = createAbstractControlSpy(123456);
+
+        expect(directive.validate(control)).toEqual({ maxDigits: true });
+    });
+});

--- a/src/lib/directives/number/nguard-max-digits.directive.ts
+++ b/src/lib/directives/number/nguard-max-digits.directive.ts
@@ -1,0 +1,22 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { NumberValidators } from '../../validators/number.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardMaxDigitsDirective,
+        },
+    ],
+    selector: '[nguardMaxDigits]',
+    standalone: true,
+})
+export class NguardMaxDigitsDirective implements Validator {
+    public readonly maxDigits = input.required<number>({ alias: 'nguardMaxDigits' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return NumberValidators.maxDigits(this.maxDigits())(control);
+    }
+}

--- a/src/lib/directives/number/nguard-min-digits.directive.spec.ts
+++ b/src/lib/directives/number/nguard-min-digits.directive.spec.ts
@@ -1,0 +1,38 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardMinDigitsDirective } from './nguard-min-digits.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardMinDigitsDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardMinDigitsDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(
+            NguardMinDigitsDirective,
+            '<div [nguardMinDigits]="$any(value)"></div>',
+            3
+        ));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate when digit count meets the minimum', () => {
+        control = createAbstractControlSpy(123);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should validate when digit count exceeds the minimum', () => {
+        control = createAbstractControlSpy(123456);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail when digit count is below the minimum', () => {
+        control = createAbstractControlSpy(12);
+
+        expect(directive.validate(control)).toEqual({ minDigits: true });
+    });
+});

--- a/src/lib/directives/number/nguard-min-digits.directive.ts
+++ b/src/lib/directives/number/nguard-min-digits.directive.ts
@@ -1,0 +1,22 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { NumberValidators } from '../../validators/number.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardMinDigitsDirective,
+        },
+    ],
+    selector: '[nguardMinDigits]',
+    standalone: true,
+})
+export class NguardMinDigitsDirective implements Validator {
+    public readonly minDigits = input.required<number>({ alias: 'nguardMinDigits' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return NumberValidators.minDigits(this.minDigits())(control);
+    }
+}

--- a/src/lib/directives/number/nguard-multiple-of.directive.spec.ts
+++ b/src/lib/directives/number/nguard-multiple-of.directive.spec.ts
@@ -1,0 +1,32 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardMultipleOfDirective } from './nguard-multiple-of.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardMultipleOfDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardMultipleOfDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(
+            NguardMultipleOfDirective,
+            '<div [nguardMultipleOf]="$any(value)"></div>',
+            5
+        ));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate a multiple', () => {
+        control = createAbstractControlSpy(15);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail on a non-multiple', () => {
+        control = createAbstractControlSpy(7);
+
+        expect(directive.validate(control)).toEqual({ multipleOf: true });
+    });
+});

--- a/src/lib/directives/number/nguard-multiple-of.directive.ts
+++ b/src/lib/directives/number/nguard-multiple-of.directive.ts
@@ -1,0 +1,22 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { NumberValidators } from '../../validators/number.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardMultipleOfDirective,
+        },
+    ],
+    selector: '[nguardMultipleOf]',
+    standalone: true,
+})
+export class NguardMultipleOfDirective implements Validator {
+    public readonly divisor = input.required<number>({ alias: 'nguardMultipleOf' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return NumberValidators.multipleOf(this.divisor())(control);
+    }
+}

--- a/src/lib/directives/number/nguard-odd.directive.spec.ts
+++ b/src/lib/directives/number/nguard-odd.directive.spec.ts
@@ -1,0 +1,34 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardOddDirective } from './nguard-odd.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardOddDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardOddDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(NguardOddDirective, '<div nguardOdd></div>'));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate an odd integer', () => {
+        control = createAbstractControlSpy(3);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail on an even integer', () => {
+        control = createAbstractControlSpy(4);
+
+        expect(directive.validate(control)).toEqual({ odd: true });
+    });
+
+    it('should fail on a non-integer', () => {
+        control = createAbstractControlSpy(3.5);
+
+        expect(directive.validate(control)).toEqual({ odd: true });
+    });
+});

--- a/src/lib/directives/number/nguard-odd.directive.ts
+++ b/src/lib/directives/number/nguard-odd.directive.ts
@@ -1,0 +1,20 @@
+import { Directive } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { NumberValidators } from '../../validators/number.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardOddDirective,
+        },
+    ],
+    selector: '[nguardOdd]',
+    standalone: true,
+})
+export class NguardOddDirective implements Validator {
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return NumberValidators.odd(control);
+    }
+}

--- a/src/lib/validators/number.validators.spec.ts
+++ b/src/lib/validators/number.validators.spec.ts
@@ -475,3 +475,145 @@ describe('Number Validators - Lesser Than or Equal', () => {
         expect(NumberValidators.lesserThanOrEqual('')(control)).toEqual({ lesserThanOrEqual: true });
     });
 });
+
+describe('Number Validators - Digits', () => {
+    it('Valid for matching digit count', () => {
+        control = createAbstractControlSpy(1234);
+
+        expect(NumberValidators.digits(4)(control)).toBeNull();
+    });
+
+    it('Valid for negative integer with matching digit count', () => {
+        control = createAbstractControlSpy(-1234);
+
+        expect(NumberValidators.digits(4)(control)).toBeNull();
+    });
+
+    it('Valid for numeric string', () => {
+        control = createAbstractControlSpy('12345');
+
+        expect(NumberValidators.digits(5)(control)).toBeNull();
+    });
+
+    it('Invalid for too few digits', () => {
+        control = createAbstractControlSpy(123);
+
+        expect(NumberValidators.digits(4)(control)).toEqual({ digits: true });
+    });
+
+    it('Invalid for too many digits', () => {
+        control = createAbstractControlSpy(12345);
+
+        expect(NumberValidators.digits(4)(control)).toEqual({ digits: true });
+    });
+
+    it('Invalid for non-integer', () => {
+        control = createAbstractControlSpy(12.34);
+
+        expect(NumberValidators.digits(4)(control)).toEqual({ digits: true });
+    });
+
+    it('Invalid for non-numeric input', () => {
+        control = createAbstractControlSpy('abc');
+
+        expect(NumberValidators.digits(3)(control)).toEqual({ digits: true });
+    });
+
+    it('Invalid for null input', () => {
+        control = createAbstractControlSpy(null);
+
+        expect(NumberValidators.digits(1)(control)).toEqual({ digits: true });
+    });
+});
+
+describe('Number Validators - Digits Between', () => {
+    it('Valid at lower bound', () => {
+        control = createAbstractControlSpy(123);
+
+        expect(NumberValidators.digitsBetween(3, 5)(control)).toBeNull();
+    });
+
+    it('Valid at upper bound', () => {
+        control = createAbstractControlSpy(12345);
+
+        expect(NumberValidators.digitsBetween(3, 5)(control)).toBeNull();
+    });
+
+    it('Invalid below lower bound', () => {
+        control = createAbstractControlSpy(12);
+
+        expect(NumberValidators.digitsBetween(3, 5)(control)).toEqual({ digitsBetween: true });
+    });
+
+    it('Invalid above upper bound', () => {
+        control = createAbstractControlSpy(123456);
+
+        expect(NumberValidators.digitsBetween(3, 5)(control)).toEqual({ digitsBetween: true });
+    });
+
+    it('Throws when min > max', () => {
+        control = createAbstractControlSpy(123);
+
+        expect(() => NumberValidators.digitsBetween(5, 3)(control)).toThrowError(
+            RangeValidatorErrors.MinGreaterThanMax
+        );
+    });
+
+    it('Invalid for non-integer', () => {
+        control = createAbstractControlSpy(12.3);
+
+        expect(NumberValidators.digitsBetween(2, 5)(control)).toEqual({ digitsBetween: true });
+    });
+});
+
+describe('Number Validators - Min Digits', () => {
+    it('Valid when digit count equals minimum', () => {
+        control = createAbstractControlSpy(123);
+
+        expect(NumberValidators.minDigits(3)(control)).toBeNull();
+    });
+
+    it('Valid when digit count exceeds minimum', () => {
+        control = createAbstractControlSpy(123456);
+
+        expect(NumberValidators.minDigits(3)(control)).toBeNull();
+    });
+
+    it('Invalid below minimum', () => {
+        control = createAbstractControlSpy(12);
+
+        expect(NumberValidators.minDigits(3)(control)).toEqual({ minDigits: true });
+    });
+
+    it('Invalid for non-numeric', () => {
+        control = createAbstractControlSpy('abc');
+
+        expect(NumberValidators.minDigits(1)(control)).toEqual({ minDigits: true });
+    });
+});
+
+describe('Number Validators - Max Digits', () => {
+    it('Valid at maximum', () => {
+        control = createAbstractControlSpy(12345);
+
+        expect(NumberValidators.maxDigits(5)(control)).toBeNull();
+    });
+
+    it('Valid below maximum', () => {
+        control = createAbstractControlSpy(12);
+
+        expect(NumberValidators.maxDigits(5)(control)).toBeNull();
+    });
+
+    it('Invalid above maximum', () => {
+        control = createAbstractControlSpy(123456);
+
+        expect(NumberValidators.maxDigits(5)(control)).toEqual({ maxDigits: true });
+    });
+
+    it('Invalid for non-integer', () => {
+        control = createAbstractControlSpy(1.2);
+
+        expect(NumberValidators.maxDigits(5)(control)).toEqual({ maxDigits: true });
+    });
+});

--- a/src/lib/validators/number.validators.spec.ts
+++ b/src/lib/validators/number.validators.spec.ts
@@ -729,3 +729,79 @@ describe('Number Validators - Multiple Of', () => {
         expect(NumberValidators.multipleOf(5)(control)).toEqual({ multipleOf: true });
     });
 });
+
+describe('Number Validators - Even', () => {
+    it('Valid for an even integer', () => {
+        control = createAbstractControlSpy(4);
+
+        expect(NumberValidators.even(control)).toBeNull();
+    });
+
+    it('Valid for zero', () => {
+        control = createAbstractControlSpy(0);
+
+        expect(NumberValidators.even(control)).toBeNull();
+    });
+
+    it('Valid for negative even', () => {
+        control = createAbstractControlSpy(-6);
+
+        expect(NumberValidators.even(control)).toBeNull();
+    });
+
+    it('Invalid for an odd integer', () => {
+        control = createAbstractControlSpy(3);
+
+        expect(NumberValidators.even(control)).toEqual({ even: true });
+    });
+
+    it('Invalid for a non-integer', () => {
+        control = createAbstractControlSpy(2.5);
+
+        expect(NumberValidators.even(control)).toEqual({ even: true });
+    });
+
+    it('Invalid for non-numeric input', () => {
+        control = createAbstractControlSpy('abc');
+
+        expect(NumberValidators.even(control)).toEqual({ even: true });
+    });
+});
+
+describe('Number Validators - Odd', () => {
+    it('Valid for an odd integer', () => {
+        control = createAbstractControlSpy(3);
+
+        expect(NumberValidators.odd(control)).toBeNull();
+    });
+
+    it('Valid for negative odd', () => {
+        control = createAbstractControlSpy(-7);
+
+        expect(NumberValidators.odd(control)).toBeNull();
+    });
+
+    it('Invalid for zero', () => {
+        control = createAbstractControlSpy(0);
+
+        expect(NumberValidators.odd(control)).toEqual({ odd: true });
+    });
+
+    it('Invalid for an even integer', () => {
+        control = createAbstractControlSpy(4);
+
+        expect(NumberValidators.odd(control)).toEqual({ odd: true });
+    });
+
+    it('Invalid for a non-integer', () => {
+        control = createAbstractControlSpy(3.5);
+
+        expect(NumberValidators.odd(control)).toEqual({ odd: true });
+    });
+
+    it('Invalid for non-numeric input', () => {
+        control = createAbstractControlSpy(null);
+
+        expect(NumberValidators.odd(control)).toEqual({ odd: true });
+    });
+});

--- a/src/lib/validators/number.validators.spec.ts
+++ b/src/lib/validators/number.validators.spec.ts
@@ -617,3 +617,71 @@ describe('Number Validators - Max Digits', () => {
         expect(NumberValidators.maxDigits(5)(control)).toEqual({ maxDigits: true });
     });
 });
+
+describe('Number Validators - Decimal', () => {
+    it('Valid for exact decimal places', () => {
+        control = createAbstractControlSpy('1.23');
+
+        expect(NumberValidators.decimal(2)(control)).toBeNull();
+    });
+
+    it('Invalid for too few decimal places', () => {
+        control = createAbstractControlSpy('1.2');
+
+        expect(NumberValidators.decimal(2)(control)).toEqual({ decimal: true });
+    });
+
+    it('Invalid for too many decimal places', () => {
+        control = createAbstractControlSpy('1.234');
+
+        expect(NumberValidators.decimal(2)(control)).toEqual({ decimal: true });
+    });
+
+    it('Invalid for integer when exact decimal places required', () => {
+        control = createAbstractControlSpy(1);
+
+        expect(NumberValidators.decimal(2)(control)).toEqual({ decimal: true });
+    });
+
+    it('Valid for integer when decimal(0)', () => {
+        control = createAbstractControlSpy(42);
+
+        expect(NumberValidators.decimal(0)(control)).toBeNull();
+    });
+
+    it('Valid in range form (lower bound)', () => {
+        control = createAbstractControlSpy('1.2');
+
+        expect(NumberValidators.decimal(1, 3)(control)).toBeNull();
+    });
+
+    it('Valid in range form (upper bound)', () => {
+        control = createAbstractControlSpy('1.234');
+
+        expect(NumberValidators.decimal(1, 3)(control)).toBeNull();
+    });
+
+    it('Invalid below range', () => {
+        control = createAbstractControlSpy(1);
+
+        expect(NumberValidators.decimal(1, 3)(control)).toEqual({ decimal: true });
+    });
+
+    it('Invalid above range', () => {
+        control = createAbstractControlSpy('1.2345');
+
+        expect(NumberValidators.decimal(1, 3)(control)).toEqual({ decimal: true });
+    });
+
+    it('Throws when min > max in range form', () => {
+        control = createAbstractControlSpy('1.23');
+
+        expect(() => NumberValidators.decimal(3, 1)(control)).toThrowError(RangeValidatorErrors.MinGreaterThanMax);
+    });
+
+    it('Invalid for non-numeric input', () => {
+        control = createAbstractControlSpy('abc');
+
+        expect(NumberValidators.decimal(2)(control)).toEqual({ decimal: true });
+    });
+});

--- a/src/lib/validators/number.validators.spec.ts
+++ b/src/lib/validators/number.validators.spec.ts
@@ -685,3 +685,47 @@ describe('Number Validators - Decimal', () => {
         expect(NumberValidators.decimal(2)(control)).toEqual({ decimal: true });
     });
 });
+
+describe('Number Validators - Multiple Of', () => {
+    it('Valid for an exact multiple', () => {
+        control = createAbstractControlSpy(15);
+
+        expect(NumberValidators.multipleOf(5)(control)).toBeNull();
+    });
+
+    it('Valid for zero', () => {
+        control = createAbstractControlSpy(0);
+
+        expect(NumberValidators.multipleOf(5)(control)).toBeNull();
+    });
+
+    it('Valid for negative multiple', () => {
+        control = createAbstractControlSpy(-10);
+
+        expect(NumberValidators.multipleOf(5)(control)).toBeNull();
+    });
+
+    it('Valid for fractional multiple', () => {
+        control = createAbstractControlSpy(1.5);
+
+        expect(NumberValidators.multipleOf(0.5)(control)).toBeNull();
+    });
+
+    it('Invalid for non-multiple', () => {
+        control = createAbstractControlSpy(7);
+
+        expect(NumberValidators.multipleOf(5)(control)).toEqual({ multipleOf: true });
+    });
+
+    it('Invalid for non-numeric input', () => {
+        control = createAbstractControlSpy('abc');
+
+        expect(NumberValidators.multipleOf(5)(control)).toEqual({ multipleOf: true });
+    });
+
+    it('Invalid for null input', () => {
+        control = createAbstractControlSpy(null);
+
+        expect(NumberValidators.multipleOf(5)(control)).toEqual({ multipleOf: true });
+    });
+});

--- a/src/lib/validators/number.validators.ts
+++ b/src/lib/validators/number.validators.ts
@@ -9,6 +9,17 @@ const isNumeric = (value: unknown): boolean => {
     return !isNaN(num) && isFinite(num);
 };
 
+const _digitCount = (value: unknown): number | null => {
+    if (!isNumeric(value)) {
+        return null;
+    }
+    const num = Math.abs(Number(value));
+    if (!Number.isInteger(num)) {
+        return null;
+    }
+    return String(num).length;
+};
+
 const _compare = (value: unknown, target: unknown, op: '>' | '>=' | '<' | '<='): boolean => {
     if (!isNumeric(value) || !isNumeric(target)) {
         return false;
@@ -113,6 +124,44 @@ export namespace NumberValidators {
     };
 
     /**
+     * The field under validation must be an integer with exactly `n` digits (sign and decimal point excluded).
+     *
+     * ```
+     * pin: new FormControl('', [NumberValidators.digits(4)]),
+     * ```
+     *
+     * @param {number} n The required digit count
+     * @returns {ValidatorFn}
+     */
+    export const digits = (n: number): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            const count = _digitCount(c.value);
+            return count === n ? null : { digits: true };
+        };
+    };
+
+    /**
+     * The field under validation must be an integer whose digit count falls within `[minVal, maxVal]` (inclusive).
+     *
+     * ```
+     * code: new FormControl('', [NumberValidators.digitsBetween(4, 6)]),
+     * ```
+     *
+     * @param {number} minVal Minimum digit count
+     * @param {number} maxVal Maximum digit count
+     * @returns {ValidatorFn}
+     */
+    export const digitsBetween = (minVal: number, maxVal: number): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            if (minVal > maxVal) {
+                throw new RangeValidatorErrors.MinGreaterThanMax();
+            }
+            const count = _digitCount(c.value);
+            return count !== null && count >= minVal && count <= maxVal ? null : { digitsBetween: true };
+        };
+    };
+
+    /**
      * The field under validation must be an integer (whole number).
      *
      * ```
@@ -128,6 +177,23 @@ export namespace NumberValidators {
     };
 
     /**
+     * The field under validation must be an integer with at most `n` digits.
+     *
+     * ```
+     * code: new FormControl('', [NumberValidators.maxDigits(6)]),
+     * ```
+     *
+     * @param {number} n Maximum digit count
+     * @returns {ValidatorFn}
+     */
+    export const maxDigits = (n: number): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            const count = _digitCount(c.value);
+            return count !== null && count <= n ? null : { maxDigits: true };
+        };
+    };
+
+    /**
      * The field under validation must be less than or equal to the given maximum value.
      *
      * ```
@@ -139,6 +205,23 @@ export namespace NumberValidators {
     export const max = (maxVal: number): ValidatorFn => {
         return (c: AbstractControl): ValidationErrors | null =>
             _compare(c.value, maxVal, '<=') ? null : { max: true };
+    };
+
+    /**
+     * The field under validation must be an integer with at least `n` digits.
+     *
+     * ```
+     * id: new FormControl('', [NumberValidators.minDigits(4)]),
+     * ```
+     *
+     * @param {number} n Minimum digit count
+     * @returns {ValidatorFn}
+     */
+    export const minDigits = (n: number): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            const count = _digitCount(c.value);
+            return count !== null && count >= n ? null : { minDigits: true };
+        };
     };
 
     /**

--- a/src/lib/validators/number.validators.ts
+++ b/src/lib/validators/number.validators.ts
@@ -124,6 +124,35 @@ export namespace NumberValidators {
     };
 
     /**
+     * The field under validation must be a number with a specific count of decimal places.
+     * Pass a single argument for exact match (e.g. `decimal(2)` requires `1.23`),
+     * or two arguments for an inclusive range (e.g. `decimal(1, 3)` accepts `1.2`, `1.23`, `1.234`).
+     *
+     * ```
+     * price: new FormControl('', [NumberValidators.decimal(2)]),
+     * ```
+     *
+     * @param {number} minPlaces Required (or minimum) decimal places
+     * @param {number} [maxPlaces] Optional maximum decimal places (range form)
+     * @returns {ValidatorFn}
+     */
+    export const decimal = (minPlaces: number, maxPlaces?: number): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            if (maxPlaces !== undefined && minPlaces > maxPlaces) {
+                throw new RangeValidatorErrors.MinGreaterThanMax();
+            }
+            if (!isNumeric(c.value)) {
+                return { decimal: true };
+            }
+            const str = String(c.value);
+            const dotIndex = str.indexOf('.');
+            const places = dotIndex === -1 ? 0 : str.length - dotIndex - 1;
+            const ok = maxPlaces === undefined ? places === minPlaces : places >= minPlaces && places <= maxPlaces;
+            return ok ? null : { decimal: true };
+        };
+    };
+
+    /**
      * The field under validation must be an integer with exactly `n` digits (sign and decimal point excluded).
      *
      * ```

--- a/src/lib/validators/number.validators.ts
+++ b/src/lib/validators/number.validators.ts
@@ -153,6 +153,46 @@ export namespace NumberValidators {
     };
 
     /**
+     * The field under validation must be an even integer.
+     *
+     * ```
+     * count: new FormControl('', [NumberValidators.even]),
+     * ```
+     *
+     * @returns {ValidationErrors | null}
+     */
+    export const even = (c: AbstractControl): ValidationErrors | null => {
+        if (!isNumeric(c.value)) {
+            return { even: true };
+        }
+        const num = Number(c.value);
+        if (!Number.isInteger(num)) {
+            return { even: true };
+        }
+        return num % 2 === 0 ? null : { even: true };
+    };
+
+    /**
+     * The field under validation must be an odd integer.
+     *
+     * ```
+     * count: new FormControl('', [NumberValidators.odd]),
+     * ```
+     *
+     * @returns {ValidationErrors | null}
+     */
+    export const odd = (c: AbstractControl): ValidationErrors | null => {
+        if (!isNumeric(c.value)) {
+            return { odd: true };
+        }
+        const num = Number(c.value);
+        if (!Number.isInteger(num)) {
+            return { odd: true };
+        }
+        return num % 2 !== 0 ? null : { odd: true };
+    };
+
+    /**
      * The field under validation must be an integer with exactly `n` digits (sign and decimal point excluded).
      *
      * ```

--- a/src/lib/validators/number.validators.ts
+++ b/src/lib/validators/number.validators.ts
@@ -268,6 +268,25 @@ export namespace NumberValidators {
     };
 
     /**
+     * The field under validation must be an exact multiple of the given divisor (`value % n === 0`).
+     *
+     * ```
+     * step: new FormControl('', [NumberValidators.multipleOf(5)]),
+     * ```
+     *
+     * @param {number} n The divisor
+     * @returns {ValidatorFn}
+     */
+    export const multipleOf = (n: number): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            if (!isNumeric(c.value)) {
+                return { multipleOf: true };
+            }
+            return Number(c.value) % n === 0 ? null : { multipleOf: true };
+        };
+    };
+
+    /**
      * The field under validation must be a negative number (less than 0).
      *
      * ```

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -18,6 +18,7 @@ export * from './lib/directives/cross-field/nguard-required-if.directive';
 export * from './lib/directives/cross-field/nguard-same.directive';
 // - number
 export * from './lib/directives/number/nguard-between.directive';
+export * from './lib/directives/number/nguard-decimal.directive';
 export * from './lib/directives/number/nguard-digits.directive';
 export * from './lib/directives/number/nguard-digits-between.directive';
 export * from './lib/directives/number/nguard-greater-than.directive';

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -18,13 +18,17 @@ export * from './lib/directives/cross-field/nguard-required-if.directive';
 export * from './lib/directives/cross-field/nguard-same.directive';
 // - number
 export * from './lib/directives/number/nguard-between.directive';
+export * from './lib/directives/number/nguard-digits.directive';
+export * from './lib/directives/number/nguard-digits-between.directive';
 export * from './lib/directives/number/nguard-greater-than.directive';
 export * from './lib/directives/number/nguard-greater-than-or-equal.directive';
 export * from './lib/directives/number/nguard-integer.directive';
 export * from './lib/directives/number/nguard-lesser-than.directive';
 export * from './lib/directives/number/nguard-lesser-than-or-equal.directive';
 export * from './lib/directives/number/nguard-max.directive';
+export * from './lib/directives/number/nguard-max-digits.directive';
 export * from './lib/directives/number/nguard-min.directive';
+export * from './lib/directives/number/nguard-min-digits.directive';
 export * from './lib/directives/number/nguard-negative.directive';
 export * from './lib/directives/number/nguard-numeric.directive';
 export * from './lib/directives/number/nguard-positive.directive';

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -30,6 +30,7 @@ export * from './lib/directives/number/nguard-max.directive';
 export * from './lib/directives/number/nguard-max-digits.directive';
 export * from './lib/directives/number/nguard-min.directive';
 export * from './lib/directives/number/nguard-min-digits.directive';
+export * from './lib/directives/number/nguard-multiple-of.directive';
 export * from './lib/directives/number/nguard-negative.directive';
 export * from './lib/directives/number/nguard-numeric.directive';
 export * from './lib/directives/number/nguard-positive.directive';

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -21,6 +21,7 @@ export * from './lib/directives/number/nguard-between.directive';
 export * from './lib/directives/number/nguard-decimal.directive';
 export * from './lib/directives/number/nguard-digits.directive';
 export * from './lib/directives/number/nguard-digits-between.directive';
+export * from './lib/directives/number/nguard-even.directive';
 export * from './lib/directives/number/nguard-greater-than.directive';
 export * from './lib/directives/number/nguard-greater-than-or-equal.directive';
 export * from './lib/directives/number/nguard-integer.directive';
@@ -33,6 +34,7 @@ export * from './lib/directives/number/nguard-min-digits.directive';
 export * from './lib/directives/number/nguard-multiple-of.directive';
 export * from './lib/directives/number/nguard-negative.directive';
 export * from './lib/directives/number/nguard-numeric.directive';
+export * from './lib/directives/number/nguard-odd.directive';
 export * from './lib/directives/number/nguard-positive.directive';
 // - string
 export * from './lib/directives/string/nguard-alpha-dash.directive';


### PR DESCRIPTION
## Summary

v0.3.0 milestone. 8 new validators in `Number`, no new namespaces, no breaking changes.

| Commit | Validators |
|---|---|
| `2a85f3a` | `digits`, `digitsBetween`, `minDigits`, `maxDigits` (+ shared `_digitCount` primitive) |
| `a41a2a9` | `decimal` (exact form `decimal(2)` or range form `decimal(1, 3)`) |
| `7a6ccfd` | `multipleOf` |
| `487c0a6` | `even`, `odd` |

8 validators × 8 directives × specs at both layers.

## Library state after merge

- 49 → **57 validators** in 3 namespaces (CrossField · Number · String)
- v0.3.0 milestone done
- `_digitCount` joins `_compare` and `_compareLength` as a private primitive

## Test plan

- [x] `npm test` passes
- [x] `ng build` clean
- [x] Public API exports updated for all 8 directives
- [x] Each validator has matching directive (parity invariant)

## Out of scope (next)

- v0.4.0 Date & Time (still open: do dates get their own namespace or live in `String`?)
- v0.5.0 Conditional Logic (extends `CrossField`)

Closes #33