### PR TITLE
chore: rename npm package to ng-nguard

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An Angular validation library inspired by Laravel's validation approach. Provide
 ## Installation
 
 ```bash
-npm install nguard
+npm install ng-nguard
 ```
 
 ## Requirements
@@ -22,7 +22,7 @@ npm install nguard
 ### Reactive Forms
 
 ```typescript
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 import { FormControl, FormGroup } from '@angular/forms';
 
 const form = new FormGroup({

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -15,7 +15,7 @@ Both call the same underlying logic; they're never out of sync.
 ## Installation
 
 ```bash
-npm install nguard
+npm install ng-nguard
 ```
 
 **Peer requirements:** Angular `>=17.3`, since validators rely on signal-based directive inputs that became stable in 17.3.
@@ -24,7 +24,7 @@ npm install nguard
 
 ```ts
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const form = new FormGroup({
     email: new FormControl('', [Validators.required, NguardValidators.String.email]),
@@ -47,7 +47,7 @@ import {
     NguardEmailDirective,
     NguardMinLengthDirective,
     NguardSameDirective,
-} from 'nguard';
+} from 'ng-nguard';
 
 @Component({
     standalone: true,

--- a/docs/docs/validators/cross-field/confirmed.md
+++ b/docs/docs/validators/cross-field/confirmed.md
@@ -20,7 +20,7 @@ NguardValidators.CrossField.confirmed(fieldKey: string): ValidatorFn
 
 ```ts
 import { FormControl, FormGroup } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const form = new FormGroup({
     password: new FormControl(''),

--- a/docs/docs/validators/cross-field/different.md
+++ b/docs/docs/validators/cross-field/different.md
@@ -24,7 +24,7 @@ NguardValidators.CrossField.different(
 
 ```ts
 import { FormControl, FormGroup } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const form = new FormGroup({
     oldEmail: new FormControl('user@old.com'),

--- a/docs/docs/validators/cross-field/required-if.md
+++ b/docs/docs/validators/cross-field/required-if.md
@@ -26,7 +26,7 @@ NguardValidators.CrossField.requiredIf(
 
 ```ts
 import { FormControl, FormGroup } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 // Required whenever 'paymentMethod' is set to anything truthy
 new FormGroup({

--- a/docs/docs/validators/cross-field/same.md
+++ b/docs/docs/validators/cross-field/same.md
@@ -24,7 +24,7 @@ NguardValidators.CrossField.same(
 
 ```ts
 import { FormControl, FormGroup } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const form = new FormGroup({
     sourceField: new FormControl(''),

--- a/docs/docs/validators/number/between.md
+++ b/docs/docs/validators/number/between.md
@@ -21,7 +21,7 @@ NguardValidators.Number.between(minVal: number, maxVal: number): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const rating = new FormControl('', [NguardValidators.Number.between(1, 5)]);
 ```

--- a/docs/docs/validators/number/decimal.md
+++ b/docs/docs/validators/number/decimal.md
@@ -24,7 +24,7 @@ NguardValidators.Number.decimal(
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 // Exact: requires '1.23' (two decimal places)
 const price = new FormControl('', [NguardValidators.Number.decimal(2)]);

--- a/docs/docs/validators/number/digits-between.md
+++ b/docs/docs/validators/number/digits-between.md
@@ -21,7 +21,7 @@ NguardValidators.Number.digitsBetween(minVal: number, maxVal: number): Validator
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const code = new FormControl('', [NguardValidators.Number.digitsBetween(4, 6)]);
 ```

--- a/docs/docs/validators/number/digits.md
+++ b/docs/docs/validators/number/digits.md
@@ -20,7 +20,7 @@ NguardValidators.Number.digits(n: number): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const pin = new FormControl('', [NguardValidators.Number.digits(4)]);
 ```

--- a/docs/docs/validators/number/even.md
+++ b/docs/docs/validators/number/even.md
@@ -18,7 +18,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const seatsPerRow = new FormControl('', [NguardValidators.Number.even]);
 ```

--- a/docs/docs/validators/number/greater-than-or-equal.md
+++ b/docs/docs/validators/number/greater-than-or-equal.md
@@ -20,7 +20,7 @@ NguardValidators.Number.greaterThanOrEqual(fieldKey: string): ValidatorFn
 
 ```ts
 import { FormControl, FormGroup } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const range = new FormGroup({
     floor: new FormControl(0),

--- a/docs/docs/validators/number/greater-than.md
+++ b/docs/docs/validators/number/greater-than.md
@@ -20,7 +20,7 @@ NguardValidators.Number.greaterThan(fieldKey: string): ValidatorFn
 
 ```ts
 import { FormControl, FormGroup } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const range = new FormGroup({
     floor: new FormControl(0),

--- a/docs/docs/validators/number/integer.md
+++ b/docs/docs/validators/number/integer.md
@@ -18,7 +18,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const age = new FormControl('', [NguardValidators.Number.integer]);
 ```

--- a/docs/docs/validators/number/lesser-than-or-equal.md
+++ b/docs/docs/validators/number/lesser-than-or-equal.md
@@ -20,7 +20,7 @@ NguardValidators.Number.lesserThanOrEqual(fieldKey: string): ValidatorFn
 
 ```ts
 import { FormControl, FormGroup } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const range = new FormGroup({
     ceiling: new FormControl(0),

--- a/docs/docs/validators/number/lesser-than.md
+++ b/docs/docs/validators/number/lesser-than.md
@@ -20,7 +20,7 @@ NguardValidators.Number.lesserThan(fieldKey: string): ValidatorFn
 
 ```ts
 import { FormControl, FormGroup } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const range = new FormGroup({
     ceiling: new FormControl(0),

--- a/docs/docs/validators/number/max-digits.md
+++ b/docs/docs/validators/number/max-digits.md
@@ -20,7 +20,7 @@ NguardValidators.Number.maxDigits(n: number): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const code = new FormControl('', [NguardValidators.Number.maxDigits(6)]);
 ```

--- a/docs/docs/validators/number/max.md
+++ b/docs/docs/validators/number/max.md
@@ -20,7 +20,7 @@ NguardValidators.Number.max(maxVal: number): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const quantity = new FormControl('', [NguardValidators.Number.max(100)]);
 ```

--- a/docs/docs/validators/number/min-digits.md
+++ b/docs/docs/validators/number/min-digits.md
@@ -20,7 +20,7 @@ NguardValidators.Number.minDigits(n: number): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const id = new FormControl('', [NguardValidators.Number.minDigits(4)]);
 ```

--- a/docs/docs/validators/number/min.md
+++ b/docs/docs/validators/number/min.md
@@ -20,7 +20,7 @@ NguardValidators.Number.min(minVal: number): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const age = new FormControl('', [NguardValidators.Number.min(18)]);
 ```

--- a/docs/docs/validators/number/multiple-of.md
+++ b/docs/docs/validators/number/multiple-of.md
@@ -20,7 +20,7 @@ NguardValidators.Number.multipleOf(n: number): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 // Multiples of 5 — accepts 0, 5, 10, -5, etc.
 const step = new FormControl('', [NguardValidators.Number.multipleOf(5)]);

--- a/docs/docs/validators/number/negative.md
+++ b/docs/docs/validators/number/negative.md
@@ -18,7 +18,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const temperature = new FormControl('', [NguardValidators.Number.negative]);
 ```

--- a/docs/docs/validators/number/numeric.md
+++ b/docs/docs/validators/number/numeric.md
@@ -18,7 +18,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const price = new FormControl('', [NguardValidators.Number.numeric]);
 ```

--- a/docs/docs/validators/number/odd.md
+++ b/docs/docs/validators/number/odd.md
@@ -18,7 +18,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const cardsInHand = new FormControl('', [NguardValidators.Number.odd]);
 ```

--- a/docs/docs/validators/number/positive.md
+++ b/docs/docs/validators/number/positive.md
@@ -18,7 +18,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const amount = new FormControl('', [NguardValidators.Number.positive]);
 ```

--- a/docs/docs/validators/string/alpha-dash.md
+++ b/docs/docs/validators/string/alpha-dash.md
@@ -16,7 +16,7 @@ NguardValidators.String.alphaDash(hasAsciiOnly?: boolean): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const username = new FormControl('', [NguardValidators.String.alphaDash()]);
 

--- a/docs/docs/validators/string/alpha-num.md
+++ b/docs/docs/validators/string/alpha-num.md
@@ -16,7 +16,7 @@ NguardValidators.String.alphaNum(hasAsciiOnly?: boolean): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const code = new FormControl('', [NguardValidators.String.alphaNum()]);
 const ascii = new FormControl('', [NguardValidators.String.alphaNum(true)]);

--- a/docs/docs/validators/string/alpha.md
+++ b/docs/docs/validators/string/alpha.md
@@ -16,7 +16,7 @@ NguardValidators.String.alpha(hasAsciiOnly?: boolean): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 // Unicode alphabetic — accepts 'café', '日本'
 const name = new FormControl('', [NguardValidators.String.alpha()]);

--- a/docs/docs/validators/string/ascii.md
+++ b/docs/docs/validators/string/ascii.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const safeId = new FormControl('', [NguardValidators.String.ascii]);
 ```

--- a/docs/docs/validators/string/contains.md
+++ b/docs/docs/validators/string/contains.md
@@ -16,7 +16,7 @@ NguardValidators.String.contains(...values: primitive[]): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const description = new FormControl('', [
     NguardValidators.String.contains('angular', 'nguard'),

--- a/docs/docs/validators/string/doesnt-end-with.md
+++ b/docs/docs/validators/string/doesnt-end-with.md
@@ -16,7 +16,7 @@ NguardValidators.String.doesntEndWith(...values: primitive[]): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 // Reject filenames ending in temp extensions
 const filename = new FormControl('', [

--- a/docs/docs/validators/string/doesnt-start-with.md
+++ b/docs/docs/validators/string/doesnt-start-with.md
@@ -16,7 +16,7 @@ NguardValidators.String.doesntStartWith(...values: primitive[]): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 // Reject relative protocol URLs
 const externalUrl = new FormControl('', [

--- a/docs/docs/validators/string/email.md
+++ b/docs/docs/validators/string/email.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const email = new FormControl('', [NguardValidators.String.email]);
 ```

--- a/docs/docs/validators/string/ends-with.md
+++ b/docs/docs/validators/string/ends-with.md
@@ -16,7 +16,7 @@ NguardValidators.String.endsWith(...values: primitive[]): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const filename = new FormControl('', [
     NguardValidators.String.endsWith('.png', '.jpg', '.gif'),

--- a/docs/docs/validators/string/hex-color.md
+++ b/docs/docs/validators/string/hex-color.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const accent = new FormControl('', [NguardValidators.String.hexColor]);
 ```

--- a/docs/docs/validators/string/ip.md
+++ b/docs/docs/validators/string/ip.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const address = new FormControl('', [NguardValidators.String.ip]);
 ```

--- a/docs/docs/validators/string/ipv4.md
+++ b/docs/docs/validators/string/ipv4.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const address = new FormControl('', [NguardValidators.String.ipv4]);
 ```

--- a/docs/docs/validators/string/ipv6.md
+++ b/docs/docs/validators/string/ipv6.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const address = new FormControl('', [NguardValidators.String.ipv6]);
 ```

--- a/docs/docs/validators/string/json.md
+++ b/docs/docs/validators/string/json.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const config = new FormControl('', [NguardValidators.String.json]);
 ```

--- a/docs/docs/validators/string/length.md
+++ b/docs/docs/validators/string/length.md
@@ -16,7 +16,7 @@ NguardValidators.String.length(n: number): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const code = new FormControl('', [NguardValidators.String.length(6)]);
 ```

--- a/docs/docs/validators/string/longer-or-equal-to.md
+++ b/docs/docs/validators/string/longer-or-equal-to.md
@@ -16,7 +16,7 @@ NguardValidators.String.longerOrEqualTo(fieldKey: string): ValidatorFn
 
 ```ts
 import { FormControl, FormGroup } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const form = new FormGroup({
     minPassword: new FormControl(''),

--- a/docs/docs/validators/string/longer-than.md
+++ b/docs/docs/validators/string/longer-than.md
@@ -16,7 +16,7 @@ NguardValidators.String.longerThan(fieldKey: string): ValidatorFn
 
 ```ts
 import { FormControl, FormGroup } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const form = new FormGroup({
     password: new FormControl(''),

--- a/docs/docs/validators/string/lowercase.md
+++ b/docs/docs/validators/string/lowercase.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const slug = new FormControl('', [NguardValidators.String.lowercase]);
 ```

--- a/docs/docs/validators/string/mac-address.md
+++ b/docs/docs/validators/string/mac-address.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const address = new FormControl('', [NguardValidators.String.macAddress]);
 ```

--- a/docs/docs/validators/string/max-length.md
+++ b/docs/docs/validators/string/max-length.md
@@ -16,7 +16,7 @@ NguardValidators.String.maxLength(n: number): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const username = new FormControl('', [NguardValidators.String.maxLength(20)]);
 ```

--- a/docs/docs/validators/string/min-length.md
+++ b/docs/docs/validators/string/min-length.md
@@ -16,7 +16,7 @@ NguardValidators.String.minLength(n: number): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const password = new FormControl('', [NguardValidators.String.minLength(8)]);
 ```

--- a/docs/docs/validators/string/not-blank.md
+++ b/docs/docs/validators/string/not-blank.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const title = new FormControl('', [NguardValidators.String.notBlank]);
 ```

--- a/docs/docs/validators/string/not-contains.md
+++ b/docs/docs/validators/string/not-contains.md
@@ -16,7 +16,7 @@ NguardValidators.String.notContains(...values: primitive[]): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const message = new FormControl('', [
     NguardValidators.String.notContains('badword', 'forbidden'),

--- a/docs/docs/validators/string/not-regex.md
+++ b/docs/docs/validators/string/not-regex.md
@@ -16,7 +16,7 @@ NguardValidators.String.notRegex(pattern: RegExp): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 // Reject any digit in the username
 const username = new FormControl('', [

--- a/docs/docs/validators/string/regex.md
+++ b/docs/docs/validators/string/regex.md
@@ -16,7 +16,7 @@ NguardValidators.String.regex(pattern: RegExp): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 // Three uppercase letters
 const code = new FormControl('', [

--- a/docs/docs/validators/string/shorter-or-equal-to.md
+++ b/docs/docs/validators/string/shorter-or-equal-to.md
@@ -16,7 +16,7 @@ NguardValidators.String.shorterOrEqualTo(fieldKey: string): ValidatorFn
 
 ```ts
 import { FormControl, FormGroup } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const form = new FormGroup({
     fullName: new FormControl(''),

--- a/docs/docs/validators/string/shorter-than.md
+++ b/docs/docs/validators/string/shorter-than.md
@@ -16,7 +16,7 @@ NguardValidators.String.shorterThan(fieldKey: string): ValidatorFn
 
 ```ts
 import { FormControl, FormGroup } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const form = new FormGroup({
     fullName: new FormControl(''),

--- a/docs/docs/validators/string/slug.md
+++ b/docs/docs/validators/string/slug.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const slug = new FormControl('', [NguardValidators.String.slug]);
 ```

--- a/docs/docs/validators/string/starts-with.md
+++ b/docs/docs/validators/string/starts-with.md
@@ -16,7 +16,7 @@ NguardValidators.String.startsWith(...values: primitive[]): ValidatorFn
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const url = new FormControl('', [
     NguardValidators.String.startsWith('http://', 'https://'),

--- a/docs/docs/validators/string/string.md
+++ b/docs/docs/validators/string/string.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const note = new FormControl('', [NguardValidators.String.string]);
 ```

--- a/docs/docs/validators/string/ulid.md
+++ b/docs/docs/validators/string/ulid.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const id = new FormControl('', [NguardValidators.String.ulid]);
 ```

--- a/docs/docs/validators/string/uppercase.md
+++ b/docs/docs/validators/string/uppercase.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const code = new FormControl('', [NguardValidators.String.uppercase]);
 ```

--- a/docs/docs/validators/string/url.md
+++ b/docs/docs/validators/string/url.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const homepage = new FormControl('', [NguardValidators.String.url]);
 ```

--- a/docs/docs/validators/string/uuid.md
+++ b/docs/docs/validators/string/uuid.md
@@ -14,7 +14,7 @@ A parameterless validator — used directly without invocation.
 
 ```ts
 import { FormControl } from '@angular/forms';
-import { NguardValidators } from 'nguard';
+import { NguardValidators } from 'ng-nguard';
 
 const id = new FormControl('', [NguardValidators.String.uuid]);
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nguard",
+  "name": "ng-nguard",
   "version": "0.1.0",
   "engines": {
     "node": ">=18.13.0 || >=20.9.0",


### PR DESCRIPTION
## Summary

Aligns the npm package name with the portfolio convention (`ng-ncached`, `ng-qubee`).

| Layer | Change |
|---|---|
| `package.json` `"name"` | `nguard` → `ng-nguard` |
| README install command | `npm install nguard` → `npm install ng-nguard` |
| README import example | `from 'nguard'` → `from 'ng-nguard'` |
| 59 doc-page code examples | `from 'nguard'` → `from 'ng-nguard'` |
| Docusaurus Getting Started | install command + import strings |
| Class names, namespace, selectors, repo, folder | **No change** |

60 files touched, +63/-63 lines — purely a string rename.

## Verification

- [x] `ng build` clean
- [x] `cd docs && npm run build` clean
- [x] `grep -rn "from 'nguard'" docs/docs docs/src` returns nothing
- [x] `grep -rn "npm install nguard" docs/docs docs/src` returns nothing

## Out of scope

The README contains other staleness (references to the old `Multi` namespace, the dropped `gt`/`lt` aliases, Angular 17.1 floor instead of 17.3) — flagged for a separate refresh PR. Strict atomic-commit hygiene: the rename is one concern, the README architectural drift is another.

Closes #41