### PR TITLE
chore: deploy docs site to GitHub Pages on every push to develop

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,62 @@
+name: Deploy docs to GitHub Pages
+
+on:
+    push:
+        branches: [develop]
+        paths:
+            - 'docs/**'
+            - '.github/workflows/deploy-docs.yml'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+    pages: write
+    id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between in-progress
+# and the latest queued. Don't cancel in-progress runs — let the latest deploy
+# finish to avoid leaving the site in a broken intermediate state.
+concurrency:
+    group: pages
+    cancel-in-progress: false
+
+jobs:
+    build:
+        name: Build docs
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: docs
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: npm
+                  cache-dependency-path: docs/package-lock.json
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Build site
+              run: npm run build
+
+            - name: Upload Pages artifact
+              uses: actions/upload-pages-artifact@v3
+              with:
+                  path: docs/build
+
+    deploy:
+        name: Deploy
+        needs: build
+        runs-on: ubuntu-latest
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        steps:
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v4

--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,0 +1,1 @@
+nguard.andreatantimonaco.me


### PR DESCRIPTION
## Summary

Wires up automatic deployment of [nguard.andreatantimonaco.me](https://nguard.andreatantimonaco.me) on every push to `develop`.

| File | Purpose |
|---|---|
| `.github/workflows/deploy-docs.yml` | Build + deploy workflow |
| `docs/static/CNAME` | `nguard.andreatantimonaco.me` (pinned domain) |

## Workflow

- **Trigger:** push to `develop` with changes under `docs/**` (path filter avoids re-deploying on source-only changes), plus manual `workflow_dispatch`
- **Build:** Node 20 → `npm ci` → `npm run build` in `docs/`
- **Deploy:** native `actions/deploy-pages@v4` (no `gh-pages` branch)
- **Concurrency:** single-flight, no in-progress cancellation (avoids leaving the site half-deployed)

## CNAME copying

Verified locally: `cd docs && npm run build` → `cat build/CNAME` → `nguard.andreatantimonaco.me`. Docusaurus copies `docs/static/*` to the artifact root, so GitHub Pages picks it up automatically.

## After this merges (one-time manual setup)

1. **Repo Settings → Pages → Source = "GitHub Actions"** (currently likely "None")
2. **DNS provider:** add a `CNAME` record `nguard` → `andreaalhena.github.io`
3. **Repo Settings → Pages → Custom domain:** enter `nguard.andreatantimonaco.me` and wait for DNS check + HTTPS provisioning

## Test plan

- [x] Workflow YAML structure valid (Docusaurus build path, Pages action versions correct)
- [x] `cd docs && npm run build` includes CNAME in `build/CNAME`
- [ ] First run on `develop` after merge succeeds (build job)
- [ ] After Pages source is set to GitHub Actions, deploy job publishes the site

## Out of scope

- Switching deploy source to `main` post-1.0 (release-cut model). Easy follow-up when you cut 1.0 — just edit the workflow's `branches:` trigger.

Closes #45