### PR TITLE
feat(boolean): v0.6.0 — Boolean namespace with 7 validators

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -246,11 +246,11 @@ The architectural refactor (umbrella issue #12, six PRs) reshaped the library be
 
 ### Tasks
 
-- [ ] Create `BooleanValidators` namespace
-- [ ] Implement 7 boolean validators
-- [ ] Create directives for all new validators
-- [ ] Write unit tests
-- [ ] Update documentation site
+- [x] Create `BooleanValidators` namespace
+- [x] Implement 7 boolean validators
+- [x] Create directives for all new validators
+- [x] Write unit tests
+- [x] Update documentation site
 
 **Total new validators: 7**
 

--- a/docs/docs/validators/boolean/accepted-if.md
+++ b/docs/docs/validators/boolean/accepted-if.md
@@ -1,0 +1,71 @@
+# `acceptedIf`
+
+Conditional [`accepted`](./accepted): the value must be one of the accepted set **only when** a sibling field matches a trigger condition.
+
+## Signature
+
+```ts
+NguardValidators.Boolean.acceptedIf(
+    fieldKey: string,
+    value?: primitive,
+    isStrict?: boolean,
+): ValidatorFn
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `fieldKey` | `string` | — | The key of the sibling field whose value triggers the rule |
+| `value` | `primitive` (optional) | `undefined` | If provided, the sibling must equal this value to trigger the rule |
+| `isStrict` | `boolean` | `false` | If `true`, the equality check against `value` is strict (`===`) |
+
+When the condition is not met any value passes — the rule only kicks in when the sibling matches.
+
+## Reactive forms
+
+```ts
+import { FormControl, FormGroup } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+// 'agreedToProTerms' is required to be accepted whenever 'subscriptionTier' is 'pro'
+new FormGroup({
+    subscriptionTier: new FormControl(''),
+    agreedToProTerms: new FormControl(false, [
+        NguardValidators.Boolean.acceptedIf('subscriptionTier', 'pro'),
+    ]),
+});
+```
+
+## Template-driven forms
+
+```html
+<!-- Shorthand: required to be accepted when 'isPaid' is truthy -->
+<input
+    type="checkbox"
+    ngModel
+    name="agreedToTerms"
+    [nguardAcceptedIf]="'isPaid'"
+/>
+
+<!-- Object form: required to be accepted when sibling equals a specific value -->
+<input
+    type="checkbox"
+    ngModel
+    name="agreedToProTerms"
+    [nguardAcceptedIf]="{ fieldKey: 'subscriptionTier', value: 'pro' }"
+/>
+```
+
+## Error key
+
+`{ acceptedIf: true }`
+
+## Notes
+
+- The accepted set matches Laravel exactly: `true`, `'true'`, `1`, `'1'`, `'yes'`, `'on'`. Case-sensitive.
+- When the trigger value is omitted, any truthy sibling value triggers the rule.
+- When the control has no parent form group the rule never triggers and any value passes.
+
+## See also
+
+- [`accepted`](./accepted) — unconditional acceptance
+- [`declinedIf`](./declined-if) — opposite intent

--- a/docs/docs/validators/boolean/accepted.md
+++ b/docs/docs/validators/boolean/accepted.md
@@ -1,0 +1,52 @@
+# `accepted`
+
+Validate that the value is one of the **accepted** values (Laravel parity). Useful for terms-of-service checkboxes, opt-ins and "I agree" controls that may be backed by a string toggle, a numeric toggle or a boolean.
+
+## Signature
+
+```ts
+NguardValidators.Boolean.accepted: ValidatorFn
+```
+
+| Accepted input | Notes |
+|---|---|
+| `true` | native boolean |
+| `'true'` | stringified boolean |
+| `1` | numeric truth |
+| `'1'` | stringified numeric truth |
+| `'yes'` | lowercase string |
+| `'on'` | lowercase string (matches checkbox HTML) |
+
+The check is **case-sensitive** — `'Yes'` and `'YES'` are not accepted. Anything outside the list above fails.
+
+## Reactive forms
+
+```ts
+import { FormControl, FormGroup } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+const form = new FormGroup({
+    agreedToTerms: new FormControl(false, [NguardValidators.Boolean.accepted]),
+});
+```
+
+## Template-driven forms
+
+```html
+<input type="checkbox" ngModel name="agreedToTerms" nguardAccepted />
+```
+
+## Error key
+
+`{ accepted: true }`
+
+## Notes
+
+- Match Laravel's `accepted` rule exactly. If you need looser semantics (e.g. accept any truthy JS value), use [`truthy`](./truthy).
+- Pair with `acceptedIf` (planned) when the requirement is conditional on a sibling field.
+
+## See also
+
+- [`declined`](./declined) — opposite check
+- [`boolean`](./boolean) — strict boolean-like type check
+- [`truthy`](./truthy) — any JS truthy value

--- a/docs/docs/validators/boolean/accepted.md
+++ b/docs/docs/validators/boolean/accepted.md
@@ -43,10 +43,11 @@ const form = new FormGroup({
 ## Notes
 
 - Match Laravel's `accepted` rule exactly. If you need looser semantics (e.g. accept any truthy JS value), use [`truthy`](./truthy).
-- Pair with `acceptedIf` (planned) when the requirement is conditional on a sibling field.
+- Pair with [`acceptedIf`](./accepted-if) when the requirement is conditional on a sibling field.
 
 ## See also
 
+- [`acceptedIf`](./accepted-if) — conditional variant
 - [`declined`](./declined) — opposite check
 - [`boolean`](./boolean) — strict boolean-like type check
 - [`truthy`](./truthy) — any JS truthy value

--- a/docs/docs/validators/boolean/boolean.md
+++ b/docs/docs/validators/boolean/boolean.md
@@ -1,0 +1,52 @@
+---
+slug: /validators/boolean/boolean
+---
+
+# `boolean`
+
+Validate that the value is **boolean-like** (Laravel parity). Accepts the same six inputs as Laravel's `boolean` rule.
+
+## Signature
+
+```ts
+NguardValidators.Boolean.boolean: ValidatorFn
+```
+
+| Accepted input | Notes |
+|---|---|
+| `true`, `false` | native booleans |
+| `1`, `0` | numeric truth/false |
+| `'1'`, `'0'` | stringified numeric truth/false |
+
+Anything else — including `'true'`, `'false'`, `'yes'`, `null`, `undefined` — fails.
+
+## Reactive forms
+
+```ts
+import { FormControl, FormGroup } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+const form = new FormGroup({
+    isActive: new FormControl(false, [NguardValidators.Boolean.boolean]),
+});
+```
+
+## Template-driven forms
+
+```html
+<input ngModel name="isActive" nguardBoolean />
+```
+
+## Error key
+
+`{ boolean: true }`
+
+## Notes
+
+- This is a **type/shape** check — for "value evaluates as truthy" use [`truthy`](./truthy).
+- `null` and `undefined` are rejected. Pair with another rule (e.g. an explicit nullable check) if you want to allow them.
+
+## See also
+
+- [`truthy`](./truthy) — any truthy value
+- [`falsy`](./falsy) — any falsy value

--- a/docs/docs/validators/boolean/boolean.md
+++ b/docs/docs/validators/boolean/boolean.md
@@ -43,10 +43,12 @@ const form = new FormGroup({
 
 ## Notes
 
-- This is a **type/shape** check — for "value evaluates as truthy" use [`truthy`](./truthy).
+- This is a **type/shape** check — for "value evaluates as truthy" use [`truthy`](./truthy); for accepting strings like `'yes'` and `'on'` use [`accepted`](./accepted).
 - `null` and `undefined` are rejected. Pair with another rule (e.g. an explicit nullable check) if you want to allow them.
 
 ## See also
 
+- [`accepted`](./accepted) — Laravel-style acceptance set
+- [`declined`](./declined) — Laravel-style decline set
 - [`truthy`](./truthy) — any truthy value
 - [`falsy`](./falsy) — any falsy value

--- a/docs/docs/validators/boolean/declined-if.md
+++ b/docs/docs/validators/boolean/declined-if.md
@@ -1,0 +1,71 @@
+# `declinedIf`
+
+Conditional [`declined`](./declined): the value must be one of the declined set **only when** a sibling field matches a trigger condition.
+
+## Signature
+
+```ts
+NguardValidators.Boolean.declinedIf(
+    fieldKey: string,
+    value?: primitive,
+    isStrict?: boolean,
+): ValidatorFn
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `fieldKey` | `string` | — | The key of the sibling field whose value triggers the rule |
+| `value` | `primitive` (optional) | `undefined` | If provided, the sibling must equal this value to trigger the rule |
+| `isStrict` | `boolean` | `false` | If `true`, the equality check against `value` is strict (`===`) |
+
+When the condition is not met any value passes — the rule only kicks in when the sibling matches.
+
+## Reactive forms
+
+```ts
+import { FormControl, FormGroup } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+// 'wantsMarketingEmails' must be declined when 'role' is 'guest'
+new FormGroup({
+    role: new FormControl(''),
+    wantsMarketingEmails: new FormControl(true, [
+        NguardValidators.Boolean.declinedIf('role', 'guest'),
+    ]),
+});
+```
+
+## Template-driven forms
+
+```html
+<!-- Shorthand: must be declined when 'isReadOnlyMode' is truthy -->
+<input
+    type="checkbox"
+    ngModel
+    name="allowEdits"
+    [nguardDeclinedIf]="'isReadOnlyMode'"
+/>
+
+<!-- Object form: must be declined when sibling equals a specific value -->
+<input
+    type="checkbox"
+    ngModel
+    name="wantsMarketingEmails"
+    [nguardDeclinedIf]="{ fieldKey: 'role', value: 'guest' }"
+/>
+```
+
+## Error key
+
+`{ declinedIf: true }`
+
+## Notes
+
+- The declined set matches Laravel exactly: `false`, `'false'`, `0`, `'0'`, `'no'`, `'off'`. Case-sensitive.
+- When the trigger value is omitted, any truthy sibling value triggers the rule.
+- When the control has no parent form group the rule never triggers and any value passes.
+
+## See also
+
+- [`declined`](./declined) — unconditional decline
+- [`acceptedIf`](./accepted-if) — opposite intent

--- a/docs/docs/validators/boolean/declined.md
+++ b/docs/docs/validators/boolean/declined.md
@@ -43,10 +43,11 @@ const form = new FormGroup({
 ## Notes
 
 - Match Laravel's `declined` rule exactly. If you need looser semantics (e.g. accept any falsy JS value), use [`falsy`](./falsy).
-- Pair with `declinedIf` (planned) when the requirement is conditional on a sibling field.
+- Pair with [`declinedIf`](./declined-if) when the requirement is conditional on a sibling field.
 
 ## See also
 
+- [`declinedIf`](./declined-if) — conditional variant
 - [`accepted`](./accepted) — opposite check
 - [`boolean`](./boolean) — strict boolean-like type check
 - [`falsy`](./falsy) — any JS falsy value

--- a/docs/docs/validators/boolean/declined.md
+++ b/docs/docs/validators/boolean/declined.md
@@ -1,0 +1,52 @@
+# `declined`
+
+Validate that the value is one of the **declined** values (Laravel parity). The mirror of [`accepted`](./accepted) — useful for opt-out toggles or "I do not agree" controls.
+
+## Signature
+
+```ts
+NguardValidators.Boolean.declined: ValidatorFn
+```
+
+| Accepted input | Notes |
+|---|---|
+| `false` | native boolean |
+| `'false'` | stringified boolean |
+| `0` | numeric false |
+| `'0'` | stringified numeric false |
+| `'no'` | lowercase string |
+| `'off'` | lowercase string (matches checkbox HTML) |
+
+The check is **case-sensitive** — `'No'` and `'OFF'` are not accepted. Anything outside the list above fails.
+
+## Reactive forms
+
+```ts
+import { FormControl, FormGroup } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+const form = new FormGroup({
+    optedOut: new FormControl(false, [NguardValidators.Boolean.declined]),
+});
+```
+
+## Template-driven forms
+
+```html
+<input type="checkbox" ngModel name="optedOut" nguardDeclined />
+```
+
+## Error key
+
+`{ declined: true }`
+
+## Notes
+
+- Match Laravel's `declined` rule exactly. If you need looser semantics (e.g. accept any falsy JS value), use [`falsy`](./falsy).
+- Pair with `declinedIf` (planned) when the requirement is conditional on a sibling field.
+
+## See also
+
+- [`accepted`](./accepted) — opposite check
+- [`boolean`](./boolean) — strict boolean-like type check
+- [`falsy`](./falsy) — any JS falsy value

--- a/docs/docs/validators/boolean/falsy.md
+++ b/docs/docs/validators/boolean/falsy.md
@@ -33,9 +33,10 @@ const form = new FormGroup({
 
 ## Notes
 
-- Strings like `'false'` and `'0'` are **truthy** in JavaScript (they are non-empty strings) and therefore fail this rule.
+- Strings like `'false'` and `'0'` are **truthy** in JavaScript (they are non-empty strings) and therefore fail this rule. If you want Laravel-style decline semantics, use [`declined`](./declined).
 
 ## See also
 
 - [`truthy`](./truthy) — opposite check
+- [`declined`](./declined) — Laravel-style decline set
 - [`boolean`](./boolean) — strict boolean-like type check

--- a/docs/docs/validators/boolean/falsy.md
+++ b/docs/docs/validators/boolean/falsy.md
@@ -1,0 +1,41 @@
+# `falsy`
+
+Validate that the value is **falsy** in the JavaScript sense — i.e. `Boolean(value)` evaluates to `false`.
+
+## Signature
+
+```ts
+NguardValidators.Boolean.falsy: ValidatorFn
+```
+
+Accepts: `false`, `0`, `''`, `null`, `undefined`, `NaN`. Rejects everything else.
+
+## Reactive forms
+
+```ts
+import { FormControl, FormGroup } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+const form = new FormGroup({
+    optedOut: new FormControl(false, [NguardValidators.Boolean.falsy]),
+});
+```
+
+## Template-driven forms
+
+```html
+<input ngModel name="optedOut" nguardFalsy />
+```
+
+## Error key
+
+`{ falsy: true }`
+
+## Notes
+
+- Strings like `'false'` and `'0'` are **truthy** in JavaScript (they are non-empty strings) and therefore fail this rule.
+
+## See also
+
+- [`truthy`](./truthy) — opposite check
+- [`boolean`](./boolean) — strict boolean-like type check

--- a/docs/docs/validators/boolean/truthy.md
+++ b/docs/docs/validators/boolean/truthy.md
@@ -33,9 +33,10 @@ const form = new FormGroup({
 
 ## Notes
 
-- This is purely about JavaScript truthiness. Strings like `'false'` and `'0'` are truthy because they are non-empty strings.
+- This is purely about JavaScript truthiness. Strings like `'false'` and `'0'` are truthy because they are non-empty strings — if you need Laravel-style acceptance, use [`accepted`](./accepted).
 
 ## See also
 
 - [`falsy`](./falsy) — opposite check
+- [`accepted`](./accepted) — Laravel-style acceptance set
 - [`boolean`](./boolean) — strict boolean-like type check

--- a/docs/docs/validators/boolean/truthy.md
+++ b/docs/docs/validators/boolean/truthy.md
@@ -1,0 +1,41 @@
+# `truthy`
+
+Validate that the value is **truthy** in the JavaScript sense — i.e. `Boolean(value)` evaluates to `true`.
+
+## Signature
+
+```ts
+NguardValidators.Boolean.truthy: ValidatorFn
+```
+
+Rejects every falsy value: `false`, `0`, `''`, `null`, `undefined`, `NaN`. Accepts everything else.
+
+## Reactive forms
+
+```ts
+import { FormControl, FormGroup } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+const form = new FormGroup({
+    confirmed: new FormControl(true, [NguardValidators.Boolean.truthy]),
+});
+```
+
+## Template-driven forms
+
+```html
+<input ngModel name="confirmed" nguardTruthy />
+```
+
+## Error key
+
+`{ truthy: true }`
+
+## Notes
+
+- This is purely about JavaScript truthiness. Strings like `'false'` and `'0'` are truthy because they are non-empty strings.
+
+## See also
+
+- [`falsy`](./falsy) — opposite check
+- [`boolean`](./boolean) — strict boolean-like type check

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -10,8 +10,10 @@ const sidebars: SidebarsConfig = {
             link: { type: 'generated-index', title: 'Boolean validators' },
             items: [
                 'validators/boolean/accepted',
+                'validators/boolean/accepted-if',
                 'validators/boolean/boolean',
                 'validators/boolean/declined',
+                'validators/boolean/declined-if',
                 'validators/boolean/falsy',
                 'validators/boolean/truthy',
             ],

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -8,7 +8,13 @@ const sidebars: SidebarsConfig = {
             type: 'category',
             label: 'Boolean',
             link: { type: 'generated-index', title: 'Boolean validators' },
-            items: ['validators/boolean/boolean', 'validators/boolean/falsy', 'validators/boolean/truthy'],
+            items: [
+                'validators/boolean/accepted',
+                'validators/boolean/boolean',
+                'validators/boolean/declined',
+                'validators/boolean/falsy',
+                'validators/boolean/truthy',
+            ],
         },
         {
             type: 'category',

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -6,6 +6,12 @@ const sidebars: SidebarsConfig = {
         'architecture',
         {
             type: 'category',
+            label: 'Boolean',
+            link: { type: 'generated-index', title: 'Boolean validators' },
+            items: ['validators/boolean/boolean', 'validators/boolean/falsy', 'validators/boolean/truthy'],
+        },
+        {
+            type: 'category',
             label: 'CrossField',
             link: { type: 'generated-index', title: 'CrossField validators' },
             items: [

--- a/src/lib/directives/boolean/nguard-accepted-if.directive.spec.ts
+++ b/src/lib/directives/boolean/nguard-accepted-if.directive.spec.ts
@@ -1,0 +1,65 @@
+import { ComponentFixture } from '@angular/core/testing';
+import { AbstractControl } from '@angular/forms';
+import { NguardAcceptedIfDirective } from './nguard-accepted-if.directive';
+import { createAbstractControlSpyWithSibling, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
+
+describe('NguardAcceptedIfDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardAcceptedIfDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
+
+    beforeEach(() => {
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardAcceptedIfDirective,
+            '<div [nguardAcceptedIf]="$any(value)"></div>',
+            'fieldKey'
+        ));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should pass when sibling is empty (condition not met) / config as string', () => {
+        control = createAbstractControlSpyWithSibling(false, '');
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should pass when sibling is truthy and value is in the accepted set / config as string', () => {
+        control = createAbstractControlSpyWithSibling('yes', 'sibling');
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail when sibling is truthy and value is not in the accepted set / config as string', () => {
+        control = createAbstractControlSpyWithSibling(false, 'sibling');
+
+        expect(directive.validate(control)).toEqual({ acceptedIf: true });
+    });
+
+    it('should pass when sibling matches trigger value and value is accepted / config as object', () => {
+        control = createAbstractControlSpyWithSibling(true, 'pro');
+        host.value = { fieldKey: 'fieldKey', value: 'pro' };
+        fixture.detectChanges();
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail when sibling matches trigger value and value is not accepted / config as object', () => {
+        control = createAbstractControlSpyWithSibling('Yes', 'pro');
+        host.value = { fieldKey: 'fieldKey', value: 'pro' };
+        fixture.detectChanges();
+
+        expect(directive.validate(control)).toEqual({ acceptedIf: true });
+    });
+
+    it('should distinguish string and number under strict comparison / config as object', () => {
+        control = createAbstractControlSpyWithSibling(false, '1');
+        host.value = { fieldKey: 'fieldKey', isStrict: true, value: 1 };
+        fixture.detectChanges();
+
+        expect(directive.validate(control)).toBeNull();
+    });
+});

--- a/src/lib/directives/boolean/nguard-accepted-if.directive.ts
+++ b/src/lib/directives/boolean/nguard-accepted-if.directive.ts
@@ -1,0 +1,28 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { BooleanValidators } from '../../validators/boolean.validators';
+import { FieldConditionConfig } from '../../types/field-condition-config.type';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardAcceptedIfDirective,
+        },
+    ],
+    selector: '[nguardAcceptedIf]',
+    standalone: true,
+})
+export class NguardAcceptedIfDirective implements Validator {
+    public readonly config = input.required<string | FieldConditionConfig>({ alias: 'nguardAcceptedIf' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        const cfg = this.config();
+        const fieldKey = typeof cfg === 'string' ? cfg : cfg.fieldKey;
+        const isStrict = typeof cfg === 'string' ? undefined : cfg.isStrict;
+        const value = typeof cfg === 'string' ? undefined : cfg.value;
+
+        return BooleanValidators.acceptedIf(fieldKey, value, isStrict)(control);
+    }
+}

--- a/src/lib/directives/boolean/nguard-accepted.directive.spec.ts
+++ b/src/lib/directives/boolean/nguard-accepted.directive.spec.ts
@@ -1,0 +1,46 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardAcceptedDirective } from './nguard-accepted.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardAcceptedDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardAcceptedDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(NguardAcceptedDirective, '<div nguardAccepted></div>'));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate true', () => {
+        control = createAbstractControlSpy(true);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should validate the string "yes"', () => {
+        control = createAbstractControlSpy('yes');
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should validate the string "on"', () => {
+        control = createAbstractControlSpy('on');
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail on false', () => {
+        control = createAbstractControlSpy(false);
+
+        expect(directive.validate(control)).toEqual({ accepted: true });
+    });
+
+    it('should fail on the string "Yes" with different case', () => {
+        control = createAbstractControlSpy('Yes');
+
+        expect(directive.validate(control)).toEqual({ accepted: true });
+    });
+});

--- a/src/lib/directives/boolean/nguard-accepted.directive.ts
+++ b/src/lib/directives/boolean/nguard-accepted.directive.ts
@@ -1,0 +1,20 @@
+import { Directive } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { BooleanValidators } from '../../validators/boolean.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardAcceptedDirective,
+        },
+    ],
+    selector: '[nguardAccepted]',
+    standalone: true,
+})
+export class NguardAcceptedDirective implements Validator {
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return BooleanValidators.accepted(control);
+    }
+}

--- a/src/lib/directives/boolean/nguard-boolean.directive.spec.ts
+++ b/src/lib/directives/boolean/nguard-boolean.directive.spec.ts
@@ -1,0 +1,40 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardBooleanDirective } from './nguard-boolean.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardBooleanDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardBooleanDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(NguardBooleanDirective, '<div nguardBoolean></div>'));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate true', () => {
+        control = createAbstractControlSpy(true);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should validate the string "0"', () => {
+        control = createAbstractControlSpy('0');
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail on a non boolean-like string', () => {
+        control = createAbstractControlSpy('yes');
+
+        expect(directive.validate(control)).toEqual({ boolean: true });
+    });
+
+    it('should fail on null', () => {
+        control = createAbstractControlSpy(null);
+
+        expect(directive.validate(control)).toEqual({ boolean: true });
+    });
+});

--- a/src/lib/directives/boolean/nguard-boolean.directive.ts
+++ b/src/lib/directives/boolean/nguard-boolean.directive.ts
@@ -1,0 +1,20 @@
+import { Directive } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { BooleanValidators } from '../../validators/boolean.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardBooleanDirective,
+        },
+    ],
+    selector: '[nguardBoolean]',
+    standalone: true,
+})
+export class NguardBooleanDirective implements Validator {
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return BooleanValidators.boolean(control);
+    }
+}

--- a/src/lib/directives/boolean/nguard-declined-if.directive.spec.ts
+++ b/src/lib/directives/boolean/nguard-declined-if.directive.spec.ts
@@ -1,0 +1,65 @@
+import { ComponentFixture } from '@angular/core/testing';
+import { AbstractControl } from '@angular/forms';
+import { NguardDeclinedIfDirective } from './nguard-declined-if.directive';
+import { createAbstractControlSpyWithSibling, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
+
+describe('NguardDeclinedIfDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardDeclinedIfDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
+
+    beforeEach(() => {
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardDeclinedIfDirective,
+            '<div [nguardDeclinedIf]="$any(value)"></div>',
+            'fieldKey'
+        ));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should pass when sibling is empty (condition not met) / config as string', () => {
+        control = createAbstractControlSpyWithSibling(true, '');
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should pass when sibling is truthy and value is in the declined set / config as string', () => {
+        control = createAbstractControlSpyWithSibling('no', 'sibling');
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail when sibling is truthy and value is not in the declined set / config as string', () => {
+        control = createAbstractControlSpyWithSibling(true, 'sibling');
+
+        expect(directive.validate(control)).toEqual({ declinedIf: true });
+    });
+
+    it('should pass when sibling matches trigger value and value is declined / config as object', () => {
+        control = createAbstractControlSpyWithSibling(false, 'guest');
+        host.value = { fieldKey: 'fieldKey', value: 'guest' };
+        fixture.detectChanges();
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail when sibling matches trigger value and value is not declined / config as object', () => {
+        control = createAbstractControlSpyWithSibling('No', 'guest');
+        host.value = { fieldKey: 'fieldKey', value: 'guest' };
+        fixture.detectChanges();
+
+        expect(directive.validate(control)).toEqual({ declinedIf: true });
+    });
+
+    it('should distinguish string and number under strict comparison / config as object', () => {
+        control = createAbstractControlSpyWithSibling(true, '1');
+        host.value = { fieldKey: 'fieldKey', isStrict: true, value: 1 };
+        fixture.detectChanges();
+
+        expect(directive.validate(control)).toBeNull();
+    });
+});

--- a/src/lib/directives/boolean/nguard-declined-if.directive.ts
+++ b/src/lib/directives/boolean/nguard-declined-if.directive.ts
@@ -1,0 +1,28 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { BooleanValidators } from '../../validators/boolean.validators';
+import { FieldConditionConfig } from '../../types/field-condition-config.type';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardDeclinedIfDirective,
+        },
+    ],
+    selector: '[nguardDeclinedIf]',
+    standalone: true,
+})
+export class NguardDeclinedIfDirective implements Validator {
+    public readonly config = input.required<string | FieldConditionConfig>({ alias: 'nguardDeclinedIf' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        const cfg = this.config();
+        const fieldKey = typeof cfg === 'string' ? cfg : cfg.fieldKey;
+        const isStrict = typeof cfg === 'string' ? undefined : cfg.isStrict;
+        const value = typeof cfg === 'string' ? undefined : cfg.value;
+
+        return BooleanValidators.declinedIf(fieldKey, value, isStrict)(control);
+    }
+}

--- a/src/lib/directives/boolean/nguard-declined.directive.spec.ts
+++ b/src/lib/directives/boolean/nguard-declined.directive.spec.ts
@@ -1,0 +1,46 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardDeclinedDirective } from './nguard-declined.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardDeclinedDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardDeclinedDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(NguardDeclinedDirective, '<div nguardDeclined></div>'));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate false', () => {
+        control = createAbstractControlSpy(false);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should validate the string "no"', () => {
+        control = createAbstractControlSpy('no');
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should validate the string "off"', () => {
+        control = createAbstractControlSpy('off');
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail on true', () => {
+        control = createAbstractControlSpy(true);
+
+        expect(directive.validate(control)).toEqual({ declined: true });
+    });
+
+    it('should fail on the string "No" with different case', () => {
+        control = createAbstractControlSpy('No');
+
+        expect(directive.validate(control)).toEqual({ declined: true });
+    });
+});

--- a/src/lib/directives/boolean/nguard-declined.directive.ts
+++ b/src/lib/directives/boolean/nguard-declined.directive.ts
@@ -1,0 +1,20 @@
+import { Directive } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { BooleanValidators } from '../../validators/boolean.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardDeclinedDirective,
+        },
+    ],
+    selector: '[nguardDeclined]',
+    standalone: true,
+})
+export class NguardDeclinedDirective implements Validator {
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return BooleanValidators.declined(control);
+    }
+}

--- a/src/lib/directives/boolean/nguard-falsy.directive.spec.ts
+++ b/src/lib/directives/boolean/nguard-falsy.directive.spec.ts
@@ -1,0 +1,40 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardFalsyDirective } from './nguard-falsy.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardFalsyDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardFalsyDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(NguardFalsyDirective, '<div nguardFalsy></div>'));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate false', () => {
+        control = createAbstractControlSpy(false);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should validate an empty string', () => {
+        control = createAbstractControlSpy('');
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should validate null', () => {
+        control = createAbstractControlSpy(null);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail on a truthy value', () => {
+        control = createAbstractControlSpy('hello');
+
+        expect(directive.validate(control)).toEqual({ falsy: true });
+    });
+});

--- a/src/lib/directives/boolean/nguard-falsy.directive.ts
+++ b/src/lib/directives/boolean/nguard-falsy.directive.ts
@@ -1,0 +1,20 @@
+import { Directive } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { BooleanValidators } from '../../validators/boolean.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardFalsyDirective,
+        },
+    ],
+    selector: '[nguardFalsy]',
+    standalone: true,
+})
+export class NguardFalsyDirective implements Validator {
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return BooleanValidators.falsy(control);
+    }
+}

--- a/src/lib/directives/boolean/nguard-truthy.directive.spec.ts
+++ b/src/lib/directives/boolean/nguard-truthy.directive.spec.ts
@@ -1,0 +1,46 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardTruthyDirective } from './nguard-truthy.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardTruthyDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardTruthyDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(NguardTruthyDirective, '<div nguardTruthy></div>'));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate true', () => {
+        control = createAbstractControlSpy(true);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should validate a non empty string', () => {
+        control = createAbstractControlSpy('hello');
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail on false', () => {
+        control = createAbstractControlSpy(false);
+
+        expect(directive.validate(control)).toEqual({ truthy: true });
+    });
+
+    it('should fail on null', () => {
+        control = createAbstractControlSpy(null);
+
+        expect(directive.validate(control)).toEqual({ truthy: true });
+    });
+
+    it('should fail on the number zero', () => {
+        control = createAbstractControlSpy(0);
+
+        expect(directive.validate(control)).toEqual({ truthy: true });
+    });
+});

--- a/src/lib/directives/boolean/nguard-truthy.directive.ts
+++ b/src/lib/directives/boolean/nguard-truthy.directive.ts
@@ -1,0 +1,20 @@
+import { Directive } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { BooleanValidators } from '../../validators/boolean.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardTruthyDirective,
+        },
+    ],
+    selector: '[nguardTruthy]',
+    standalone: true,
+})
+export class NguardTruthyDirective implements Validator {
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return BooleanValidators.truthy(control);
+    }
+}

--- a/src/lib/utils/validators.utils.ts
+++ b/src/lib/utils/validators.utils.ts
@@ -1,3 +1,5 @@
+import { AbstractControl } from '@angular/forms';
+
 export type primitive = boolean | number | string;
 
 export const equalityCheck = (value1: unknown, value2: unknown, isStrict: boolean = false): boolean => {
@@ -6,6 +8,30 @@ export const equalityCheck = (value1: unknown, value2: unknown, isStrict: boolea
     }
     // eslint-disable-next-line eqeqeq -- Intentional loose comparison for type coercion
     return value1 == value2;
+};
+
+/**
+ * Evaluate whether the sibling identified by `fieldKey` satisfies the trigger condition.
+ * If `value` is omitted the sibling must simply be truthy. If `value` is provided the
+ * sibling must equal it (loose equality by default, strict when `isStrict` is true).
+ *
+ * Shared by the cross-field conditional family (requiredUnless, presentIf, presentUnless,
+ * prohibitedIf, prohibitedUnless) and by the boolean conditional pair (acceptedIf, declinedIf).
+ */
+export const evaluateCondition = (
+    control: AbstractControl,
+    fieldKey: string,
+    value?: primitive,
+    isStrict: boolean = false
+): boolean => {
+    const siblingValue = control.parent?.get(fieldKey)?.value;
+    const hasTriggerValue = value !== undefined;
+
+    if (!hasTriggerValue) {
+        return Boolean(siblingValue);
+    }
+
+    return equalityCheck(siblingValue, value, isStrict);
 };
 
 export const haveSameType = (value1: unknown, value2: unknown): boolean => typeof value1 === typeof value2;

--- a/src/lib/validators/boolean.validators.spec.ts
+++ b/src/lib/validators/boolean.validators.spec.ts
@@ -4,6 +4,68 @@ import { BooleanValidators } from './boolean.validators';
 
 let control: jasmine.SpyObj<AbstractControl>;
 
+describe('Boolean Validators - accepted (Laravel parity)', () => {
+    it('Accepted - Valid for the literal true', () => {
+        control = createAbstractControlSpy(true);
+
+        expect(BooleanValidators.accepted(control)).toBeNull();
+    });
+
+    it('Accepted - Valid for the string "true"', () => {
+        control = createAbstractControlSpy('true');
+
+        expect(BooleanValidators.accepted(control)).toBeNull();
+    });
+
+    it('Accepted - Valid for the number 1', () => {
+        control = createAbstractControlSpy(1);
+
+        expect(BooleanValidators.accepted(control)).toBeNull();
+    });
+
+    it('Accepted - Valid for the string "1"', () => {
+        control = createAbstractControlSpy('1');
+
+        expect(BooleanValidators.accepted(control)).toBeNull();
+    });
+
+    it('Accepted - Valid for the string "yes"', () => {
+        control = createAbstractControlSpy('yes');
+
+        expect(BooleanValidators.accepted(control)).toBeNull();
+    });
+
+    it('Accepted - Valid for the string "on"', () => {
+        control = createAbstractControlSpy('on');
+
+        expect(BooleanValidators.accepted(control)).toBeNull();
+    });
+
+    it('Accepted - Invalid for the literal false', () => {
+        control = createAbstractControlSpy(false);
+
+        expect(BooleanValidators.accepted(control)).toEqual({ accepted: true });
+    });
+
+    it('Accepted - Invalid for the string "Yes" with different case', () => {
+        control = createAbstractControlSpy('Yes');
+
+        expect(BooleanValidators.accepted(control)).toEqual({ accepted: true });
+    });
+
+    it('Accepted - Invalid for the number 2', () => {
+        control = createAbstractControlSpy(2);
+
+        expect(BooleanValidators.accepted(control)).toEqual({ accepted: true });
+    });
+
+    it('Accepted - Invalid for null', () => {
+        control = createNullControlSpy();
+
+        expect(BooleanValidators.accepted(control)).toEqual({ accepted: true });
+    });
+});
+
 describe('Boolean Validators - boolean (Laravel parity)', () => {
     it('Boolean - Valid for the literal true', () => {
         control = createAbstractControlSpy(true);
@@ -63,6 +125,68 @@ describe('Boolean Validators - boolean (Laravel parity)', () => {
         control = createUndefinedControlSpy();
 
         expect(BooleanValidators.boolean(control)).toEqual({ boolean: true });
+    });
+});
+
+describe('Boolean Validators - declined (Laravel parity)', () => {
+    it('Declined - Valid for the literal false', () => {
+        control = createAbstractControlSpy(false);
+
+        expect(BooleanValidators.declined(control)).toBeNull();
+    });
+
+    it('Declined - Valid for the string "false"', () => {
+        control = createAbstractControlSpy('false');
+
+        expect(BooleanValidators.declined(control)).toBeNull();
+    });
+
+    it('Declined - Valid for the number 0', () => {
+        control = createAbstractControlSpy(0);
+
+        expect(BooleanValidators.declined(control)).toBeNull();
+    });
+
+    it('Declined - Valid for the string "0"', () => {
+        control = createAbstractControlSpy('0');
+
+        expect(BooleanValidators.declined(control)).toBeNull();
+    });
+
+    it('Declined - Valid for the string "no"', () => {
+        control = createAbstractControlSpy('no');
+
+        expect(BooleanValidators.declined(control)).toBeNull();
+    });
+
+    it('Declined - Valid for the string "off"', () => {
+        control = createAbstractControlSpy('off');
+
+        expect(BooleanValidators.declined(control)).toBeNull();
+    });
+
+    it('Declined - Invalid for the literal true', () => {
+        control = createAbstractControlSpy(true);
+
+        expect(BooleanValidators.declined(control)).toEqual({ declined: true });
+    });
+
+    it('Declined - Invalid for the string "No" with different case', () => {
+        control = createAbstractControlSpy('No');
+
+        expect(BooleanValidators.declined(control)).toEqual({ declined: true });
+    });
+
+    it('Declined - Invalid for the empty string', () => {
+        control = createAbstractControlSpy('');
+
+        expect(BooleanValidators.declined(control)).toEqual({ declined: true });
+    });
+
+    it('Declined - Invalid for null', () => {
+        control = createNullControlSpy();
+
+        expect(BooleanValidators.declined(control)).toEqual({ declined: true });
     });
 });
 

--- a/src/lib/validators/boolean.validators.spec.ts
+++ b/src/lib/validators/boolean.validators.spec.ts
@@ -1,5 +1,10 @@
 import { AbstractControl } from '@angular/forms';
-import { createAbstractControlSpy, createNullControlSpy, createUndefinedControlSpy } from '../utils/test.utils';
+import {
+    createAbstractControlSpy,
+    createAbstractControlSpyWithSibling,
+    createNullControlSpy,
+    createUndefinedControlSpy,
+} from '../utils/test.utils';
 import { BooleanValidators } from './boolean.validators';
 
 let control: jasmine.SpyObj<AbstractControl>;
@@ -63,6 +68,44 @@ describe('Boolean Validators - accepted (Laravel parity)', () => {
         control = createNullControlSpy();
 
         expect(BooleanValidators.accepted(control)).toEqual({ accepted: true });
+    });
+});
+
+describe('Boolean Validators - acceptedIf', () => {
+    it('AcceptedIf - Valid when condition is not met regardless of value', () => {
+        control = createAbstractControlSpyWithSibling(false, '');
+
+        expect(BooleanValidators.acceptedIf('key')(control)).toBeNull();
+    });
+
+    it('AcceptedIf - Valid when sibling is truthy and value is accepted', () => {
+        control = createAbstractControlSpyWithSibling('yes', 'sibling');
+
+        expect(BooleanValidators.acceptedIf('key')(control)).toBeNull();
+    });
+
+    it('AcceptedIf - Invalid when sibling is truthy and value is not accepted', () => {
+        control = createAbstractControlSpyWithSibling(false, 'sibling');
+
+        expect(BooleanValidators.acceptedIf('key')(control)).toEqual({ acceptedIf: true });
+    });
+
+    it('AcceptedIf - Valid when sibling matches trigger value and value is accepted', () => {
+        control = createAbstractControlSpyWithSibling(true, 'pro');
+
+        expect(BooleanValidators.acceptedIf('key', 'pro')(control)).toBeNull();
+    });
+
+    it('AcceptedIf - Invalid when sibling matches trigger value but value is not accepted', () => {
+        control = createAbstractControlSpyWithSibling('Yes', 'pro');
+
+        expect(BooleanValidators.acceptedIf('key', 'pro')(control)).toEqual({ acceptedIf: true });
+    });
+
+    it('AcceptedIf - Valid when sibling does not match trigger under strict comparison', () => {
+        control = createAbstractControlSpyWithSibling(false, '1');
+
+        expect(BooleanValidators.acceptedIf('key', 1, true)(control)).toBeNull();
     });
 });
 
@@ -187,6 +230,44 @@ describe('Boolean Validators - declined (Laravel parity)', () => {
         control = createNullControlSpy();
 
         expect(BooleanValidators.declined(control)).toEqual({ declined: true });
+    });
+});
+
+describe('Boolean Validators - declinedIf', () => {
+    it('DeclinedIf - Valid when condition is not met regardless of value', () => {
+        control = createAbstractControlSpyWithSibling(true, '');
+
+        expect(BooleanValidators.declinedIf('key')(control)).toBeNull();
+    });
+
+    it('DeclinedIf - Valid when sibling is truthy and value is declined', () => {
+        control = createAbstractControlSpyWithSibling('no', 'sibling');
+
+        expect(BooleanValidators.declinedIf('key')(control)).toBeNull();
+    });
+
+    it('DeclinedIf - Invalid when sibling is truthy and value is not declined', () => {
+        control = createAbstractControlSpyWithSibling(true, 'sibling');
+
+        expect(BooleanValidators.declinedIf('key')(control)).toEqual({ declinedIf: true });
+    });
+
+    it('DeclinedIf - Valid when sibling matches trigger value and value is declined', () => {
+        control = createAbstractControlSpyWithSibling(false, 'guest');
+
+        expect(BooleanValidators.declinedIf('key', 'guest')(control)).toBeNull();
+    });
+
+    it('DeclinedIf - Invalid when sibling matches trigger value but value is not declined', () => {
+        control = createAbstractControlSpyWithSibling('No', 'guest');
+
+        expect(BooleanValidators.declinedIf('key', 'guest')(control)).toEqual({ declinedIf: true });
+    });
+
+    it('DeclinedIf - Valid when sibling does not match trigger under strict comparison', () => {
+        control = createAbstractControlSpyWithSibling(true, '1');
+
+        expect(BooleanValidators.declinedIf('key', 1, true)(control)).toBeNull();
     });
 });
 

--- a/src/lib/validators/boolean.validators.spec.ts
+++ b/src/lib/validators/boolean.validators.spec.ts
@@ -1,0 +1,167 @@
+import { AbstractControl } from '@angular/forms';
+import { createAbstractControlSpy, createNullControlSpy, createUndefinedControlSpy } from '../utils/test.utils';
+import { BooleanValidators } from './boolean.validators';
+
+let control: jasmine.SpyObj<AbstractControl>;
+
+describe('Boolean Validators - boolean (Laravel parity)', () => {
+    it('Boolean - Valid for the literal true', () => {
+        control = createAbstractControlSpy(true);
+
+        expect(BooleanValidators.boolean(control)).toBeNull();
+    });
+
+    it('Boolean - Valid for the literal false', () => {
+        control = createAbstractControlSpy(false);
+
+        expect(BooleanValidators.boolean(control)).toBeNull();
+    });
+
+    it('Boolean - Valid for the number 1', () => {
+        control = createAbstractControlSpy(1);
+
+        expect(BooleanValidators.boolean(control)).toBeNull();
+    });
+
+    it('Boolean - Valid for the number 0', () => {
+        control = createAbstractControlSpy(0);
+
+        expect(BooleanValidators.boolean(control)).toBeNull();
+    });
+
+    it('Boolean - Valid for the string "1"', () => {
+        control = createAbstractControlSpy('1');
+
+        expect(BooleanValidators.boolean(control)).toBeNull();
+    });
+
+    it('Boolean - Valid for the string "0"', () => {
+        control = createAbstractControlSpy('0');
+
+        expect(BooleanValidators.boolean(control)).toBeNull();
+    });
+
+    it('Boolean - Invalid for the string "true"', () => {
+        control = createAbstractControlSpy('true');
+
+        expect(BooleanValidators.boolean(control)).toEqual({ boolean: true });
+    });
+
+    it('Boolean - Invalid for the number 2', () => {
+        control = createAbstractControlSpy(2);
+
+        expect(BooleanValidators.boolean(control)).toEqual({ boolean: true });
+    });
+
+    it('Boolean - Invalid for null', () => {
+        control = createNullControlSpy();
+
+        expect(BooleanValidators.boolean(control)).toEqual({ boolean: true });
+    });
+
+    it('Boolean - Invalid for undefined', () => {
+        control = createUndefinedControlSpy();
+
+        expect(BooleanValidators.boolean(control)).toEqual({ boolean: true });
+    });
+});
+
+describe('Boolean Validators - falsy', () => {
+    it('Falsy - Valid for false', () => {
+        control = createAbstractControlSpy(false);
+
+        expect(BooleanValidators.falsy(control)).toBeNull();
+    });
+
+    it('Falsy - Valid for the number zero', () => {
+        control = createAbstractControlSpy(0);
+
+        expect(BooleanValidators.falsy(control)).toBeNull();
+    });
+
+    it('Falsy - Valid for the empty string', () => {
+        control = createAbstractControlSpy('');
+
+        expect(BooleanValidators.falsy(control)).toBeNull();
+    });
+
+    it('Falsy - Valid for null', () => {
+        control = createNullControlSpy();
+
+        expect(BooleanValidators.falsy(control)).toBeNull();
+    });
+
+    it('Falsy - Valid for undefined', () => {
+        control = createUndefinedControlSpy();
+
+        expect(BooleanValidators.falsy(control)).toBeNull();
+    });
+
+    it('Falsy - Invalid for true', () => {
+        control = createAbstractControlSpy(true);
+
+        expect(BooleanValidators.falsy(control)).toEqual({ falsy: true });
+    });
+
+    it('Falsy - Invalid for a non empty string', () => {
+        control = createAbstractControlSpy('hello');
+
+        expect(BooleanValidators.falsy(control)).toEqual({ falsy: true });
+    });
+
+    it('Falsy - Invalid for a non zero number', () => {
+        control = createAbstractControlSpy(42);
+
+        expect(BooleanValidators.falsy(control)).toEqual({ falsy: true });
+    });
+});
+
+describe('Boolean Validators - truthy', () => {
+    it('Truthy - Valid for true', () => {
+        control = createAbstractControlSpy(true);
+
+        expect(BooleanValidators.truthy(control)).toBeNull();
+    });
+
+    it('Truthy - Valid for a non empty string', () => {
+        control = createAbstractControlSpy('hello');
+
+        expect(BooleanValidators.truthy(control)).toBeNull();
+    });
+
+    it('Truthy - Valid for a non zero number', () => {
+        control = createAbstractControlSpy(42);
+
+        expect(BooleanValidators.truthy(control)).toBeNull();
+    });
+
+    it('Truthy - Invalid for false', () => {
+        control = createAbstractControlSpy(false);
+
+        expect(BooleanValidators.truthy(control)).toEqual({ truthy: true });
+    });
+
+    it('Truthy - Invalid for the number zero', () => {
+        control = createAbstractControlSpy(0);
+
+        expect(BooleanValidators.truthy(control)).toEqual({ truthy: true });
+    });
+
+    it('Truthy - Invalid for the empty string', () => {
+        control = createAbstractControlSpy('');
+
+        expect(BooleanValidators.truthy(control)).toEqual({ truthy: true });
+    });
+
+    it('Truthy - Invalid for null', () => {
+        control = createNullControlSpy();
+
+        expect(BooleanValidators.truthy(control)).toEqual({ truthy: true });
+    });
+
+    it('Truthy - Invalid for undefined', () => {
+        control = createUndefinedControlSpy();
+
+        expect(BooleanValidators.truthy(control)).toEqual({ truthy: true });
+    });
+});

--- a/src/lib/validators/boolean.validators.ts
+++ b/src/lib/validators/boolean.validators.ts
@@ -1,8 +1,26 @@
 import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
+const ACCEPTED_VALUES: ReadonlySet<unknown> = new Set([true, 'true', 1, '1', 'yes', 'on']);
 const BOOLEAN_LIKE_VALUES: ReadonlySet<unknown> = new Set([true, false, 1, 0, '1', '0']);
+const DECLINED_VALUES: ReadonlySet<unknown> = new Set([false, 'false', 0, '0', 'no', 'off']);
 
 export namespace BooleanValidators {
+    /**
+     * Validate that the value is one of the accepted values (Laravel parity).
+     * Accepted inputs: `true`, `'true'`, `1`, `'1'`, `'yes'`, `'on'`.
+     *
+     * ```
+     * new FormControl(true, [NguardValidators.Boolean.accepted])
+     * ```
+     *
+     * @returns {ValidationErrors | null}
+     */
+    export const accepted: ValidatorFn = (c: AbstractControl): ValidationErrors | null => {
+        const isAccepted = ACCEPTED_VALUES.has(c.value);
+
+        return isAccepted ? null : { accepted: true };
+    };
+
     /**
      * Validate that the value is boolean-like (Laravel parity).
      * Accepted inputs: `true`, `false`, `1`, `0`, `'1'`, `'0'`.
@@ -17,6 +35,22 @@ export namespace BooleanValidators {
         const isBooleanLike = BOOLEAN_LIKE_VALUES.has(c.value);
 
         return isBooleanLike ? null : { boolean: true };
+    };
+
+    /**
+     * Validate that the value is one of the declined values (Laravel parity).
+     * Accepted inputs: `false`, `'false'`, `0`, `'0'`, `'no'`, `'off'`.
+     *
+     * ```
+     * new FormControl(false, [NguardValidators.Boolean.declined])
+     * ```
+     *
+     * @returns {ValidationErrors | null}
+     */
+    export const declined: ValidatorFn = (c: AbstractControl): ValidationErrors | null => {
+        const isDeclined = DECLINED_VALUES.has(c.value);
+
+        return isDeclined ? null : { declined: true };
     };
 
     /**

--- a/src/lib/validators/boolean.validators.ts
+++ b/src/lib/validators/boolean.validators.ts
@@ -1,4 +1,5 @@
 import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { evaluateCondition, primitive } from '../utils/validators.utils';
 
 const ACCEPTED_VALUES: ReadonlySet<unknown> = new Set([true, 'true', 1, '1', 'yes', 'on']);
 const BOOLEAN_LIKE_VALUES: ReadonlySet<unknown> = new Set([true, false, 1, 0, '1', '0']);
@@ -19,6 +20,33 @@ export namespace BooleanValidators {
         const isAccepted = ACCEPTED_VALUES.has(c.value);
 
         return isAccepted ? null : { accepted: true };
+    };
+
+    /**
+     * The value must be one of the accepted values WHEN a sibling field matches the trigger
+     * condition. When the condition is not met any value is allowed.
+     *
+     * ```
+     * new FormControl(false, [
+     *   NguardValidators.Boolean.acceptedIf('subscriptionTier', 'pro')
+     * ])
+     * ```
+     *
+     * @param {string} fieldKey The key of the sibling field whose value triggers the rule
+     * @param {primitive} [value] If present, the sibling must equal this value to trigger the rule
+     * @param {boolean} [isStrict] If true, the equality check against `value` is performed with the strict equality operator
+     * @returns {ValidatorFn}
+     */
+    export const acceptedIf = (fieldKey: string, value?: primitive, isStrict: boolean = false): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            const conditionMet = evaluateCondition(c, fieldKey, value, isStrict);
+
+            if (!conditionMet) {
+                return null;
+            }
+
+            return ACCEPTED_VALUES.has(c.value) ? null : { acceptedIf: true };
+        };
     };
 
     /**
@@ -51,6 +79,33 @@ export namespace BooleanValidators {
         const isDeclined = DECLINED_VALUES.has(c.value);
 
         return isDeclined ? null : { declined: true };
+    };
+
+    /**
+     * The value must be one of the declined values WHEN a sibling field matches the trigger
+     * condition. When the condition is not met any value is allowed.
+     *
+     * ```
+     * new FormControl(false, [
+     *   NguardValidators.Boolean.declinedIf('isAdmin', true)
+     * ])
+     * ```
+     *
+     * @param {string} fieldKey The key of the sibling field whose value triggers the rule
+     * @param {primitive} [value] If present, the sibling must equal this value to trigger the rule
+     * @param {boolean} [isStrict] If true, the equality check against `value` is performed with the strict equality operator
+     * @returns {ValidatorFn}
+     */
+    export const declinedIf = (fieldKey: string, value?: primitive, isStrict: boolean = false): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            const conditionMet = evaluateCondition(c, fieldKey, value, isStrict);
+
+            if (!conditionMet) {
+                return null;
+            }
+
+            return DECLINED_VALUES.has(c.value) ? null : { declinedIf: true };
+        };
     };
 
     /**

--- a/src/lib/validators/boolean.validators.ts
+++ b/src/lib/validators/boolean.validators.ts
@@ -1,0 +1,53 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+const BOOLEAN_LIKE_VALUES: ReadonlySet<unknown> = new Set([true, false, 1, 0, '1', '0']);
+
+export namespace BooleanValidators {
+    /**
+     * Validate that the value is boolean-like (Laravel parity).
+     * Accepted inputs: `true`, `false`, `1`, `0`, `'1'`, `'0'`.
+     *
+     * ```
+     * new FormControl(false, [NguardValidators.Boolean.boolean])
+     * ```
+     *
+     * @returns {ValidationErrors | null}
+     */
+    export const boolean: ValidatorFn = (c: AbstractControl): ValidationErrors | null => {
+        const isBooleanLike = BOOLEAN_LIKE_VALUES.has(c.value);
+
+        return isBooleanLike ? null : { boolean: true };
+    };
+
+    /**
+     * Validate that the value is falsy (i.e. `!value` is true).
+     * Catches `false`, `0`, `''`, `null`, `undefined`, `NaN`.
+     *
+     * ```
+     * new FormControl(false, [NguardValidators.Boolean.falsy])
+     * ```
+     *
+     * @returns {ValidationErrors | null}
+     */
+    export const falsy: ValidatorFn = (c: AbstractControl): ValidationErrors | null => {
+        const isFalsy = !c.value;
+
+        return isFalsy ? null : { falsy: true };
+    };
+
+    /**
+     * Validate that the value is truthy (i.e. `Boolean(value)` is true).
+     * Rejects `false`, `0`, `''`, `null`, `undefined`, `NaN`.
+     *
+     * ```
+     * new FormControl(true, [NguardValidators.Boolean.truthy])
+     * ```
+     *
+     * @returns {ValidationErrors | null}
+     */
+    export const truthy: ValidatorFn = (c: AbstractControl): ValidationErrors | null => {
+        const isTruthy = Boolean(c.value);
+
+        return isTruthy ? null : { truthy: true };
+    };
+}

--- a/src/lib/validators/cross-field.validators.ts
+++ b/src/lib/validators/cross-field.validators.ts
@@ -1,28 +1,5 @@
 import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
-import { equalityCheck, primitive } from '../utils/validators.utils';
-
-/**
- * Evaluate whether the sibling identified by `fieldKey` satisfies the trigger condition.
- * If `value` is omitted the sibling must simply be truthy. If `value` is provided the
- * sibling must equal it (loose equality by default, strict when `isStrict` is true).
- *
- * Used by the conditional family — requiredUnless, presentIf, presentUnless, prohibitedIf,
- * prohibitedUnless — to decide whether the rule applies to the current control.
- */
-const _evaluateCondition = (
-    control: AbstractControl,
-    fieldKey: string,
-    value?: primitive,
-    isStrict: boolean = false
-): boolean => {
-    const siblingValue = control.parent?.get(fieldKey)?.value;
-
-    if (value === undefined) {
-        return Boolean(siblingValue);
-    }
-
-    return equalityCheck(siblingValue, value, isStrict);
-};
+import { equalityCheck, evaluateCondition, primitive } from '../utils/validators.utils';
 
 /**
  * Returns true if the sibling identified by `fieldKey` resolves to a truthy value.
@@ -99,7 +76,7 @@ export namespace CrossFieldValidators {
      */
     export const presentIf = (fieldKey: string, value?: primitive, isStrict: boolean = false): ValidatorFn => {
         return (c: AbstractControl): ValidationErrors | null => {
-            if (!_evaluateCondition(c, fieldKey, value, isStrict)) {
+            if (!evaluateCondition(c, fieldKey, value, isStrict)) {
                 return null;
             }
 
@@ -125,7 +102,7 @@ export namespace CrossFieldValidators {
      */
     export const presentUnless = (fieldKey: string, value?: primitive, isStrict: boolean = false): ValidatorFn => {
         return (c: AbstractControl): ValidationErrors | null => {
-            if (_evaluateCondition(c, fieldKey, value, isStrict)) {
+            if (evaluateCondition(c, fieldKey, value, isStrict)) {
                 return null;
             }
 
@@ -150,7 +127,7 @@ export namespace CrossFieldValidators {
      */
     export const prohibitedIf = (fieldKey: string, value?: primitive, isStrict: boolean = false): ValidatorFn => {
         return (c: AbstractControl): ValidationErrors | null => {
-            if (!_evaluateCondition(c, fieldKey, value, isStrict)) {
+            if (!evaluateCondition(c, fieldKey, value, isStrict)) {
                 return null;
             }
 
@@ -175,7 +152,7 @@ export namespace CrossFieldValidators {
      */
     export const prohibitedUnless = (fieldKey: string, value?: primitive, isStrict: boolean = false): ValidatorFn => {
         return (c: AbstractControl): ValidationErrors | null => {
-            if (_evaluateCondition(c, fieldKey, value, isStrict)) {
+            if (evaluateCondition(c, fieldKey, value, isStrict)) {
                 return null;
             }
 
@@ -231,7 +208,7 @@ export namespace CrossFieldValidators {
      */
     export const requiredUnless = (fieldKey: string, value?: primitive, isStrict: boolean = false): ValidatorFn => {
         return (c: AbstractControl): ValidationErrors | null => {
-            if (_evaluateCondition(c, fieldKey, value, isStrict)) {
+            if (evaluateCondition(c, fieldKey, value, isStrict)) {
                 return null;
             }
 

--- a/src/lib/validators/nguard.validators.ts
+++ b/src/lib/validators/nguard.validators.ts
@@ -1,8 +1,10 @@
+import { BooleanValidators } from './boolean.validators';
 import { CrossFieldValidators } from './cross-field.validators';
 import { NumberValidators } from './number.validators';
 import { StringValidators } from './string.validators';
 
 export namespace NguardValidators {
+    export const Boolean = BooleanValidators;
     export const CrossField = CrossFieldValidators;
     export const Number = NumberValidators;
     export const String = StringValidators;

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -11,6 +11,10 @@ export * from './lib/types/field-condition-config.type';
 export type { primitive } from './lib/utils/validators.utils';
 
 // Directives
+// - boolean
+export * from './lib/directives/boolean/nguard-boolean.directive';
+export * from './lib/directives/boolean/nguard-falsy.directive';
+export * from './lib/directives/boolean/nguard-truthy.directive';
 // - cross-field
 export * from './lib/directives/cross-field/nguard-confirmed.directive';
 export * from './lib/directives/cross-field/nguard-different.directive';

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -12,7 +12,9 @@ export type { primitive } from './lib/utils/validators.utils';
 
 // Directives
 // - boolean
+export * from './lib/directives/boolean/nguard-accepted.directive';
 export * from './lib/directives/boolean/nguard-boolean.directive';
+export * from './lib/directives/boolean/nguard-declined.directive';
 export * from './lib/directives/boolean/nguard-falsy.directive';
 export * from './lib/directives/boolean/nguard-truthy.directive';
 // - cross-field

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -13,8 +13,10 @@ export type { primitive } from './lib/utils/validators.utils';
 // Directives
 // - boolean
 export * from './lib/directives/boolean/nguard-accepted.directive';
+export * from './lib/directives/boolean/nguard-accepted-if.directive';
 export * from './lib/directives/boolean/nguard-boolean.directive';
 export * from './lib/directives/boolean/nguard-declined.directive';
+export * from './lib/directives/boolean/nguard-declined-if.directive';
 export * from './lib/directives/boolean/nguard-falsy.directive';
 export * from './lib/directives/boolean/nguard-truthy.directive';
 // - cross-field


### PR DESCRIPTION
## Summary

Ships v0.6.0 — a new \`NguardValidators.Boolean\` namespace with 7 validators, full validator/directive parity per validator.

- **Type/shape**: \`boolean\` (Laravel parity — accepts \`true\`/\`false\`/\`1\`/\`0\`/\`'1'\`/\`'0'\`)
- **JS truthiness**: \`truthy\`, \`falsy\`
- **Laravel acceptance**: \`accepted\` (\`true\`/\`'true'\`/\`1\`/\`'1'\`/\`'yes'\`/\`'on'\`), \`declined\` (\`false\`/\`'false'\`/\`0\`/\`'0'\`/\`'no'\`/\`'off'\`)
- **Conditional**: \`acceptedIf\`, \`declinedIf\` — sibling-conditional pair using the shared \`evaluateCondition\` helper

The \`evaluateCondition\` helper was extracted from \`cross-field.validators.ts\` to \`validators.utils.ts\` so it can back both CrossField conditionals and the Boolean conditional pair without duplication. Pure refactor, zero behavior change.

## Test plan

- [x] All tests pass (766 → 866, +100)
- [x] Docusaurus production build clean — all internal links resolve
- [x] ESLint + Prettier clean (lint-staged ran on each commit)
- [x] Public API exports updated for all 7 directives
- [x] Sidebar entry inserted alphabetically (Boolean → CrossField → Number → String)
- [x] ROADMAP.md v0.6.0 task list checked off

Closes #50