### PR TITLE
v0.7.0: Arrays & Collections — new Array namespace (10 validators)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-05-31
+
+### Added
+
+- **`Array` namespace** — new validator namespace for arrays and collections, alphabetized first across the public API and docs sidebar.
+- `Array.array` — value is a JavaScript array.
+- `Array.minSize` / `Array.maxSize` / `Array.sizeBetween` — item-count bounds.
+- `Array.distinct` — no duplicate values (Set value-equality for primitives).
+- `Array.contains` / `Array.doesntContain` — required / forbidden members.
+- `Array.inArray` — value is a member of a sibling field's array.
+- `Array.arrayOf` — every item passes a supplied validator.
+- `Array.requiredArrayKeys` — value is an object containing the given keys.
+- Matching signal-based directives for all ten validators (validator/directive parity); `contains`/`doesntContain` use the `nguardArrayContains`/`nguardArrayDoesntContain` selectors to avoid clashing with the String directives.
+- Documentation pages and an `Array` sidebar category for every new validator.
+
+### Changed
+
+- Docs version selector now reads `0.7.0`.
+
 ## [0.6.0] - 2026-05-30
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -277,12 +277,12 @@ The architectural refactor (umbrella issue #12, six PRs) reshaped the library be
 
 ### Tasks
 
-- [ ] Create `ArrayValidators` namespace
-- [ ] Implement 10 array validators
-- [ ] Support nested validation with `arrayOf`
-- [ ] Create directives for all new validators
-- [ ] Write unit tests
-- [ ] Update documentation site
+- [x] Create `ArrayValidators` namespace
+- [x] Implement 10 array validators
+- [x] Support nested validation with `arrayOf`
+- [x] Create directives for all new validators
+- [x] Write unit tests
+- [x] Update documentation site
 
 **Total new validators: 10**
 

--- a/docs/docs/validators/array/array-of.md
+++ b/docs/docs/validators/array/array-of.md
@@ -1,0 +1,54 @@
+# `arrayOf`
+
+Validate that **every item** in the array passes the supplied validator. A non-array value fails.
+
+## Signature
+
+```ts
+NguardValidators.Array.arrayOf(validator: ValidatorFn): ValidatorFn
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `validator` | `ValidatorFn` | The validator applied to each item |
+
+## Reactive forms
+
+```ts
+import { FormControl } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+// Every item must be a valid email
+new FormControl(['a@b.com', 'c@d.com'], [
+    NguardValidators.Array.arrayOf(NguardValidators.String.email),
+]);
+```
+
+## Template-driven forms
+
+```html
+<!-- bind a component property holding the per-item validator -->
+<input ngModel name="emails" [nguardArrayOf]="itemValidator" />
+```
+
+```ts
+import { NguardValidators } from 'ng-nguard';
+
+class MyComponent {
+    public readonly itemValidator = NguardValidators.String.email;
+}
+```
+
+## Error key
+
+`{ arrayOf: true }`
+
+## Notes
+
+- Each item is wrapped in a transient `FormControl` before being handed to the validator, so only **self-contained** item validators are supported — cross-field item rules (those reading a sibling) will not work.
+- An empty array passes. A non-array value fails.
+
+## See also
+
+- [`array`](./array) — value is an array
+- [`distinct`](./distinct) — no duplicates

--- a/docs/docs/validators/array/array.md
+++ b/docs/docs/validators/array/array.md
@@ -1,0 +1,43 @@
+---
+slug: /validators/array/array
+---
+
+# `array`
+
+Validate that the value is a JavaScript **array** (`Array.isArray`).
+
+## Signature
+
+```ts
+NguardValidators.Array.array: ValidatorFn
+```
+
+## Reactive forms
+
+```ts
+import { FormControl, FormGroup } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+const form = new FormGroup({
+    tags: new FormControl([], [NguardValidators.Array.array]),
+});
+```
+
+## Template-driven forms
+
+```html
+<input ngModel name="tags" nguardArray />
+```
+
+## Error key
+
+`{ array: true }`
+
+## Notes
+
+- `null`, `undefined`, objects and array-like values are rejected — only true arrays pass.
+
+## See also
+
+- [`minSize`](./min-size) — minimum item count
+- [`distinct`](./distinct) — no duplicates

--- a/docs/docs/validators/array/contains.md
+++ b/docs/docs/validators/array/contains.md
@@ -1,0 +1,48 @@
+# `contains`
+
+Validate that the array contains **every** one of the given values (membership via `Array.includes`). A non-array value fails.
+
+## Signature
+
+```ts
+NguardValidators.Array.contains(...values: primitive[]): ValidatorFn
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `...values` | `primitive[]` | The values that must all be present |
+
+## Reactive forms
+
+```ts
+import { FormControl } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+new FormControl(['read', 'write'], [NguardValidators.Array.contains('read', 'write')]);
+```
+
+## Template-driven forms
+
+```html
+<!-- Array form -->
+<input ngModel name="scopes" [nguardArrayContains]="['read', 'write']" />
+
+<!-- Single value shorthand -->
+<input ngModel name="scopes" [nguardArrayContains]="'read'" />
+```
+
+The directive selector is `nguardArrayContains` (prefixed to avoid clashing with the `String.contains` directive).
+
+## Error key
+
+`{ contains: true }`
+
+## Notes
+
+- Membership uses `Array.prototype.includes` (strict, `SameValueZero`).
+- A non-array value (including `null`/`undefined`) fails.
+
+## See also
+
+- [`doesntContain`](./doesnt-contain) — forbidden members
+- [`inArray`](./in-array) — value is a member of a sibling's array

--- a/docs/docs/validators/array/distinct.md
+++ b/docs/docs/validators/array/distinct.md
@@ -1,0 +1,42 @@
+---
+slug: /validators/array/distinct
+---
+
+# `distinct`
+
+Validate that the array has **no duplicate values**. A non-array value fails.
+
+## Signature
+
+```ts
+NguardValidators.Array.distinct: ValidatorFn
+```
+
+## Reactive forms
+
+```ts
+import { FormControl } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+new FormControl([1, 2, 3], [NguardValidators.Array.distinct]);
+```
+
+## Template-driven forms
+
+```html
+<input ngModel name="tags" nguardDistinct />
+```
+
+## Error key
+
+`{ distinct: true }`
+
+## Notes
+
+- Uniqueness is determined with `Set` value-equality: **primitives** are compared by value, **objects** by reference. Two structurally-equal objects are therefore treated as distinct.
+- A non-array value (including `null`/`undefined`) fails.
+
+## See also
+
+- [`array`](./array) — value is an array
+- [`contains`](./contains) — required members

--- a/docs/docs/validators/array/doesnt-contain.md
+++ b/docs/docs/validators/array/doesnt-contain.md
@@ -1,0 +1,47 @@
+# `doesntContain`
+
+Validate that the array contains **none** of the given values (membership via `Array.includes`). A non-array value fails.
+
+## Signature
+
+```ts
+NguardValidators.Array.doesntContain(...values: primitive[]): ValidatorFn
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `...values` | `primitive[]` | The values that must all be absent |
+
+## Reactive forms
+
+```ts
+import { FormControl } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+new FormControl(['read'], [NguardValidators.Array.doesntContain('admin', 'root')]);
+```
+
+## Template-driven forms
+
+```html
+<!-- Array form -->
+<input ngModel name="scopes" [nguardArrayDoesntContain]="['admin', 'root']" />
+
+<!-- Single value shorthand -->
+<input ngModel name="scopes" [nguardArrayDoesntContain]="'admin'" />
+```
+
+The directive selector is `nguardArrayDoesntContain` (prefixed for symmetry with `nguardArrayContains`).
+
+## Error key
+
+`{ doesntContain: true }`
+
+## Notes
+
+- Membership uses `Array.prototype.includes` (strict, `SameValueZero`).
+- A non-array value (including `null`/`undefined`) fails.
+
+## See also
+
+- [`contains`](./contains) — required members

--- a/docs/docs/validators/array/in-array.md
+++ b/docs/docs/validators/array/in-array.md
@@ -1,0 +1,49 @@
+# `inArray`
+
+Validate that the value is a **member of a sibling field's array**. Fails when the sibling is missing or is not an array.
+
+## Signature
+
+```ts
+NguardValidators.Array.inArray(fieldKey: string, isStrict?: boolean): ValidatorFn
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `fieldKey` | `string` | — | The key of the sibling field holding the array |
+| `isStrict` | `boolean` | `true` | If `true`, membership uses strict equality (`===`); loose (`==`) otherwise |
+
+## Reactive forms
+
+```ts
+import { FormControl, FormGroup } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+new FormGroup({
+    allowedColors: new FormControl(['red', 'green']),
+    color: new FormControl('red', [NguardValidators.Array.inArray('allowedColors')]),
+});
+```
+
+## Template-driven forms
+
+```html
+<!-- Shorthand: strict membership in the 'allowedColors' sibling -->
+<input ngModel name="color" [nguardInArray]="'allowedColors'" />
+
+<!-- Object form: loose membership -->
+<input ngModel name="id" [nguardInArray]="{ fieldKey: 'allowedIds', isStrict: false }" />
+```
+
+## Error key
+
+`{ inArray: true }`
+
+## Notes
+
+- Reads `control.parent?.get(fieldKey)?.value`. Fails when that sibling is missing or not an array.
+- Strict by default; pass `isStrict: false` (object form) to allow type coercion (`'1'` matches `1`).
+
+## See also
+
+- [`contains`](./contains) — array contains required members

--- a/docs/docs/validators/array/max-size.md
+++ b/docs/docs/validators/array/max-size.md
@@ -1,0 +1,41 @@
+# `maxSize`
+
+Validate that the array has **at most** `max` items. A non-array value fails.
+
+## Signature
+
+```ts
+NguardValidators.Array.maxSize(max: number): ValidatorFn
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `max` | `number` | The maximum number of items (inclusive) |
+
+## Reactive forms
+
+```ts
+import { FormControl } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+new FormControl([], [NguardValidators.Array.maxSize(3)]);
+```
+
+## Template-driven forms
+
+```html
+<input ngModel name="tags" [nguardMaxSize]="3" />
+```
+
+## Error key
+
+`{ maxSize: true }`
+
+## Notes
+
+- A non-array value (including `null`/`undefined`) fails.
+
+## See also
+
+- [`minSize`](./min-size) — minimum item count
+- [`sizeBetween`](./size-between) — bounded item count

--- a/docs/docs/validators/array/min-size.md
+++ b/docs/docs/validators/array/min-size.md
@@ -1,0 +1,41 @@
+# `minSize`
+
+Validate that the array has **at least** `min` items. A non-array value fails.
+
+## Signature
+
+```ts
+NguardValidators.Array.minSize(min: number): ValidatorFn
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `min` | `number` | The minimum number of items (inclusive) |
+
+## Reactive forms
+
+```ts
+import { FormControl } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+new FormControl([], [NguardValidators.Array.minSize(1)]);
+```
+
+## Template-driven forms
+
+```html
+<input ngModel name="tags" [nguardMinSize]="1" />
+```
+
+## Error key
+
+`{ minSize: true }`
+
+## Notes
+
+- A non-array value (including `null`/`undefined`) fails. Compose with an optional rule if empty should pass.
+
+## See also
+
+- [`maxSize`](./max-size) — maximum item count
+- [`sizeBetween`](./size-between) — bounded item count

--- a/docs/docs/validators/array/required-array-keys.md
+++ b/docs/docs/validators/array/required-array-keys.md
@@ -1,0 +1,47 @@
+# `requiredArrayKeys`
+
+Validate that the value is a **non-null object containing every one of the given keys**. Maps Laravel's `required_array_keys` rule to a plain object.
+
+## Signature
+
+```ts
+NguardValidators.Array.requiredArrayKeys(...keys: string[]): ValidatorFn
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `...keys` | `string[]` | The keys that must all be present |
+
+## Reactive forms
+
+```ts
+import { FormControl } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+new FormControl({ id: 1, name: 'x' }, [
+    NguardValidators.Array.requiredArrayKeys('id', 'name'),
+]);
+```
+
+## Template-driven forms
+
+```html
+<!-- Array form -->
+<input ngModel name="profile" [nguardRequiredArrayKeys]="['id', 'name']" />
+
+<!-- Single key shorthand -->
+<input ngModel name="profile" [nguardRequiredArrayKeys]="'id'" />
+```
+
+## Error key
+
+`{ requiredArrayKeys: true }`
+
+## Notes
+
+- Presence is checked with the `in` operator, so inherited keys count.
+- `null`, `undefined` and primitives fail — the value must be an object.
+
+## See also
+
+- [`array`](./array) — value is an array

--- a/docs/docs/validators/array/size-between.md
+++ b/docs/docs/validators/array/size-between.md
@@ -1,0 +1,43 @@
+# `sizeBetween`
+
+Validate that the array item count is within `[min, max]` **inclusive**. A non-array value fails.
+
+## Signature
+
+```ts
+NguardValidators.Array.sizeBetween(min: number, max: number): ValidatorFn
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `min` | `number` | The minimum number of items (inclusive) |
+| `max` | `number` | The maximum number of items (inclusive) |
+
+## Reactive forms
+
+```ts
+import { FormControl } from '@angular/forms';
+import { NguardValidators } from 'ng-nguard';
+
+new FormControl([], [NguardValidators.Array.sizeBetween(1, 3)]);
+```
+
+## Template-driven forms
+
+```html
+<!-- The directive takes a [min, max] tuple -->
+<input ngModel name="tags" [nguardSizeBetween]="[1, 3]" />
+```
+
+## Error key
+
+`{ sizeBetween: true }`
+
+## Notes
+
+- A non-array value (including `null`/`undefined`) fails.
+
+## See also
+
+- [`minSize`](./min-size) — minimum item count
+- [`maxSize`](./max-size) — maximum item count

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -37,7 +37,7 @@ const config: Config = {
                     lastVersion: 'current',
                     versions: {
                         current: {
-                            label: '0.6.0',
+                            label: '0.7.0',
                         },
                     },
                 },

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -6,6 +6,23 @@ const sidebars: SidebarsConfig = {
         'architecture',
         {
             type: 'category',
+            label: 'Array',
+            link: { type: 'generated-index', title: 'Array validators' },
+            items: [
+                'validators/array/array',
+                'validators/array/array-of',
+                'validators/array/contains',
+                'validators/array/distinct',
+                'validators/array/doesnt-contain',
+                'validators/array/in-array',
+                'validators/array/max-size',
+                'validators/array/min-size',
+                'validators/array/required-array-keys',
+                'validators/array/size-between',
+            ],
+        },
+        {
+            type: 'category',
             label: 'Boolean',
             link: { type: 'generated-index', title: 'Boolean validators' },
             items: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-nguard",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "engines": {
     "node": ">=18.13.0 || >=20.9.0",
     "npm": ">=9.0.0"

--- a/src/lib/directives/array/nguard-array-contains.directive.spec.ts
+++ b/src/lib/directives/array/nguard-array-contains.directive.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture } from '@angular/core/testing';
+import { AbstractControl } from '@angular/forms';
+import { NguardArrayContainsDirective } from './nguard-array-contains.directive';
+import { createAbstractControlSpy, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
+
+describe('NguardArrayContainsDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardArrayContainsDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
+
+    beforeEach(() => {
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardArrayContainsDirective,
+            '<div [nguardArrayContains]="$any(value)"></div>',
+            ['a', 'b']
+        ));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate when all required values are present / array config', () => {
+        control = createAbstractControlSpy(['a', 'b', 'c']);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail when a required value is missing / array config', () => {
+        control = createAbstractControlSpy(['a']);
+
+        expect(directive.validate(control)).toEqual({ contains: true });
+    });
+
+    it('should accept a single value shorthand', () => {
+        host.value = 'a';
+        fixture.detectChanges();
+        control = createAbstractControlSpy(['a', 'b']);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+});

--- a/src/lib/directives/array/nguard-array-contains.directive.ts
+++ b/src/lib/directives/array/nguard-array-contains.directive.ts
@@ -1,0 +1,26 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { ArrayValidators } from '../../validators/array.validators';
+import { primitive } from '../../utils/validators.utils';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardArrayContainsDirective,
+        },
+    ],
+    selector: '[nguardArrayContains]',
+    standalone: true,
+})
+export class NguardArrayContainsDirective implements Validator {
+    public readonly values = input.required<primitive | primitive[]>({ alias: 'nguardArrayContains' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        const cfg = this.values();
+        const values = Array.isArray(cfg) ? cfg : [cfg];
+
+        return ArrayValidators.contains(...values)(control);
+    }
+}

--- a/src/lib/directives/array/nguard-array-doesnt-contain.directive.spec.ts
+++ b/src/lib/directives/array/nguard-array-doesnt-contain.directive.spec.ts
@@ -1,0 +1,32 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardArrayDoesntContainDirective } from './nguard-array-doesnt-contain.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardArrayDoesntContainDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardArrayDoesntContainDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(
+            NguardArrayDoesntContainDirective,
+            '<div [nguardArrayDoesntContain]="$any(value)"></div>',
+            ['x', 'y']
+        ));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate when no forbidden values are present', () => {
+        control = createAbstractControlSpy(['a', 'b']);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail when a forbidden value is present', () => {
+        control = createAbstractControlSpy(['a', 'x']);
+
+        expect(directive.validate(control)).toEqual({ doesntContain: true });
+    });
+});

--- a/src/lib/directives/array/nguard-array-doesnt-contain.directive.ts
+++ b/src/lib/directives/array/nguard-array-doesnt-contain.directive.ts
@@ -1,0 +1,26 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { ArrayValidators } from '../../validators/array.validators';
+import { primitive } from '../../utils/validators.utils';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardArrayDoesntContainDirective,
+        },
+    ],
+    selector: '[nguardArrayDoesntContain]',
+    standalone: true,
+})
+export class NguardArrayDoesntContainDirective implements Validator {
+    public readonly values = input.required<primitive | primitive[]>({ alias: 'nguardArrayDoesntContain' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        const cfg = this.values();
+        const values = Array.isArray(cfg) ? cfg : [cfg];
+
+        return ArrayValidators.doesntContain(...values)(control);
+    }
+}

--- a/src/lib/directives/array/nguard-array-of.directive.spec.ts
+++ b/src/lib/directives/array/nguard-array-of.directive.spec.ts
@@ -1,0 +1,34 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardArrayOfDirective } from './nguard-array-of.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+const isString = (c: AbstractControl) => (typeof c.value === 'string' ? null : { notString: true });
+
+describe('NguardArrayOfDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardArrayOfDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(
+            NguardArrayOfDirective,
+            '<div [nguardArrayOf]="$any(value)"></div>',
+            isString
+        ));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate when every item passes the inner validator', () => {
+        control = createAbstractControlSpy(['a', 'b']);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail when an item fails the inner validator', () => {
+        control = createAbstractControlSpy(['a', 1]);
+
+        expect(directive.validate(control)).toEqual({ arrayOf: true });
+    });
+});

--- a/src/lib/directives/array/nguard-array-of.directive.ts
+++ b/src/lib/directives/array/nguard-array-of.directive.ts
@@ -1,0 +1,22 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator, ValidatorFn } from '@angular/forms';
+import { ArrayValidators } from '../../validators/array.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardArrayOfDirective,
+        },
+    ],
+    selector: '[nguardArrayOf]',
+    standalone: true,
+})
+export class NguardArrayOfDirective implements Validator {
+    public readonly validator = input.required<ValidatorFn>({ alias: 'nguardArrayOf' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return ArrayValidators.arrayOf(this.validator())(control);
+    }
+}

--- a/src/lib/directives/array/nguard-array.directive.spec.ts
+++ b/src/lib/directives/array/nguard-array.directive.spec.ts
@@ -1,0 +1,28 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardArrayDirective } from './nguard-array.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardArrayDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardArrayDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(NguardArrayDirective, '<div nguardArray></div>'));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate an array', () => {
+        control = createAbstractControlSpy([1, 2]);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail on a non-array', () => {
+        control = createAbstractControlSpy('x');
+
+        expect(directive.validate(control)).toEqual({ array: true });
+    });
+});

--- a/src/lib/directives/array/nguard-array.directive.ts
+++ b/src/lib/directives/array/nguard-array.directive.ts
@@ -1,0 +1,20 @@
+import { Directive } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { ArrayValidators } from '../../validators/array.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardArrayDirective,
+        },
+    ],
+    selector: '[nguardArray]',
+    standalone: true,
+})
+export class NguardArrayDirective implements Validator {
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return ArrayValidators.array(control);
+    }
+}

--- a/src/lib/directives/array/nguard-distinct.directive.spec.ts
+++ b/src/lib/directives/array/nguard-distinct.directive.spec.ts
@@ -1,0 +1,28 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardDistinctDirective } from './nguard-distinct.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardDistinctDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardDistinctDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(NguardDistinctDirective, '<div nguardDistinct></div>'));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate an array of unique values', () => {
+        control = createAbstractControlSpy([1, 2, 3]);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail on duplicate values', () => {
+        control = createAbstractControlSpy([1, 1]);
+
+        expect(directive.validate(control)).toEqual({ distinct: true });
+    });
+});

--- a/src/lib/directives/array/nguard-distinct.directive.ts
+++ b/src/lib/directives/array/nguard-distinct.directive.ts
@@ -1,0 +1,20 @@
+import { Directive } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { ArrayValidators } from '../../validators/array.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardDistinctDirective,
+        },
+    ],
+    selector: '[nguardDistinct]',
+    standalone: true,
+})
+export class NguardDistinctDirective implements Validator {
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return ArrayValidators.distinct(control);
+    }
+}

--- a/src/lib/directives/array/nguard-in-array.directive.spec.ts
+++ b/src/lib/directives/array/nguard-in-array.directive.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture } from '@angular/core/testing';
+import { AbstractControl } from '@angular/forms';
+import { NguardInArrayDirective } from './nguard-in-array.directive';
+import { createAbstractControlSpyWithSibling, createDirectiveFixture, TestHostComponent } from '../../utils/test.utils';
+
+describe('NguardInArrayDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardInArrayDirective;
+    let fixture: ComponentFixture<TestHostComponent>;
+    let host: TestHostComponent;
+
+    beforeEach(() => {
+        ({ directive, fixture, host } = createDirectiveFixture(
+            NguardInArrayDirective,
+            '<div [nguardInArray]="$any(value)"></div>',
+            'allowedColors'
+        ));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate when the value is a member of the sibling array / config as string', () => {
+        control = createAbstractControlSpyWithSibling('red', ['red', 'green']);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail when the value is not a member / config as string', () => {
+        control = createAbstractControlSpyWithSibling('blue', ['red', 'green']);
+
+        expect(directive.validate(control)).toEqual({ inArray: true });
+    });
+
+    it('should distinguish string and number under strict comparison / config as object', () => {
+        host.value = { fieldKey: 'ids', isStrict: true };
+        fixture.detectChanges();
+        control = createAbstractControlSpyWithSibling('1', [1, 2]);
+
+        expect(directive.validate(control)).toEqual({ inArray: true });
+    });
+});

--- a/src/lib/directives/array/nguard-in-array.directive.ts
+++ b/src/lib/directives/array/nguard-in-array.directive.ts
@@ -1,0 +1,27 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { ArrayValidators } from '../../validators/array.validators';
+import { FieldComparisonConfig } from '../../types/field-comparison-config.type';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardInArrayDirective,
+        },
+    ],
+    selector: '[nguardInArray]',
+    standalone: true,
+})
+export class NguardInArrayDirective implements Validator {
+    public readonly config = input.required<string | FieldComparisonConfig>({ alias: 'nguardInArray' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        const cfg = this.config();
+        const fieldKey = typeof cfg === 'string' ? cfg : cfg.fieldKey;
+        const isStrict = typeof cfg === 'string' ? undefined : cfg.isStrict;
+
+        return ArrayValidators.inArray(fieldKey, isStrict)(control);
+    }
+}

--- a/src/lib/directives/array/nguard-max-size.directive.spec.ts
+++ b/src/lib/directives/array/nguard-max-size.directive.spec.ts
@@ -1,0 +1,32 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardMaxSizeDirective } from './nguard-max-size.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardMaxSizeDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardMaxSizeDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(
+            NguardMaxSizeDirective,
+            '<div [nguardMaxSize]="$any(value)"></div>',
+            2
+        ));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate an array at or below the maximum', () => {
+        control = createAbstractControlSpy([1, 2]);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail above the maximum', () => {
+        control = createAbstractControlSpy([1, 2, 3]);
+
+        expect(directive.validate(control)).toEqual({ maxSize: true });
+    });
+});

--- a/src/lib/directives/array/nguard-max-size.directive.ts
+++ b/src/lib/directives/array/nguard-max-size.directive.ts
@@ -1,0 +1,22 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { ArrayValidators } from '../../validators/array.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardMaxSizeDirective,
+        },
+    ],
+    selector: '[nguardMaxSize]',
+    standalone: true,
+})
+export class NguardMaxSizeDirective implements Validator {
+    public readonly max = input.required<number>({ alias: 'nguardMaxSize' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return ArrayValidators.maxSize(this.max())(control);
+    }
+}

--- a/src/lib/directives/array/nguard-min-size.directive.spec.ts
+++ b/src/lib/directives/array/nguard-min-size.directive.spec.ts
@@ -1,0 +1,32 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardMinSizeDirective } from './nguard-min-size.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardMinSizeDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardMinSizeDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(
+            NguardMinSizeDirective,
+            '<div [nguardMinSize]="$any(value)"></div>',
+            2
+        ));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate an array at or above the minimum', () => {
+        control = createAbstractControlSpy([1, 2]);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail below the minimum', () => {
+        control = createAbstractControlSpy([1]);
+
+        expect(directive.validate(control)).toEqual({ minSize: true });
+    });
+});

--- a/src/lib/directives/array/nguard-min-size.directive.ts
+++ b/src/lib/directives/array/nguard-min-size.directive.ts
@@ -1,0 +1,22 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { ArrayValidators } from '../../validators/array.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardMinSizeDirective,
+        },
+    ],
+    selector: '[nguardMinSize]',
+    standalone: true,
+})
+export class NguardMinSizeDirective implements Validator {
+    public readonly min = input.required<number>({ alias: 'nguardMinSize' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return ArrayValidators.minSize(this.min())(control);
+    }
+}

--- a/src/lib/directives/array/nguard-required-array-keys.directive.spec.ts
+++ b/src/lib/directives/array/nguard-required-array-keys.directive.spec.ts
@@ -1,0 +1,32 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardRequiredArrayKeysDirective } from './nguard-required-array-keys.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardRequiredArrayKeysDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardRequiredArrayKeysDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(
+            NguardRequiredArrayKeysDirective,
+            '<div [nguardRequiredArrayKeys]="$any(value)"></div>',
+            ['id', 'name']
+        ));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate when the object has all required keys', () => {
+        control = createAbstractControlSpy({ id: 1, name: 'x' });
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail when a required key is missing', () => {
+        control = createAbstractControlSpy({ id: 1 });
+
+        expect(directive.validate(control)).toEqual({ requiredArrayKeys: true });
+    });
+});

--- a/src/lib/directives/array/nguard-required-array-keys.directive.ts
+++ b/src/lib/directives/array/nguard-required-array-keys.directive.ts
@@ -1,0 +1,25 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { ArrayValidators } from '../../validators/array.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardRequiredArrayKeysDirective,
+        },
+    ],
+    selector: '[nguardRequiredArrayKeys]',
+    standalone: true,
+})
+export class NguardRequiredArrayKeysDirective implements Validator {
+    public readonly keys = input.required<string | string[]>({ alias: 'nguardRequiredArrayKeys' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        const cfg = this.keys();
+        const keys = Array.isArray(cfg) ? cfg : [cfg];
+
+        return ArrayValidators.requiredArrayKeys(...keys)(control);
+    }
+}

--- a/src/lib/directives/array/nguard-size-between.directive.spec.ts
+++ b/src/lib/directives/array/nguard-size-between.directive.spec.ts
@@ -1,0 +1,38 @@
+import { AbstractControl } from '@angular/forms';
+import { NguardSizeBetweenDirective } from './nguard-size-between.directive';
+import { createAbstractControlSpy, createDirectiveFixture } from '../../utils/test.utils';
+
+describe('NguardSizeBetweenDirective', () => {
+    let control: AbstractControl;
+    let directive: NguardSizeBetweenDirective;
+
+    beforeEach(() => {
+        ({ directive } = createDirectiveFixture(
+            NguardSizeBetweenDirective,
+            '<div [nguardSizeBetween]="$any(value)"></div>',
+            [1, 3]
+        ));
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    it('should validate an array within the range', () => {
+        control = createAbstractControlSpy([1, 2]);
+
+        expect(directive.validate(control)).toBeNull();
+    });
+
+    it('should fail below the range', () => {
+        control = createAbstractControlSpy([]);
+
+        expect(directive.validate(control)).toEqual({ sizeBetween: true });
+    });
+
+    it('should fail above the range', () => {
+        control = createAbstractControlSpy([1, 2, 3, 4]);
+
+        expect(directive.validate(control)).toEqual({ sizeBetween: true });
+    });
+});

--- a/src/lib/directives/array/nguard-size-between.directive.ts
+++ b/src/lib/directives/array/nguard-size-between.directive.ts
@@ -1,0 +1,22 @@
+import { Directive, input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+import { ArrayValidators } from '../../validators/array.validators';
+
+@Directive({
+    providers: [
+        {
+            multi: true,
+            provide: NG_VALIDATORS,
+            useExisting: NguardSizeBetweenDirective,
+        },
+    ],
+    selector: '[nguardSizeBetween]',
+    standalone: true,
+})
+export class NguardSizeBetweenDirective implements Validator {
+    public readonly values = input.required<[number, number]>({ alias: 'nguardSizeBetween' });
+
+    public validate(control: AbstractControl): ValidationErrors | null {
+        return ArrayValidators.sizeBetween(...this.values())(control);
+    }
+}

--- a/src/lib/validators/array.validators.spec.ts
+++ b/src/lib/validators/array.validators.spec.ts
@@ -1,0 +1,301 @@
+import { AbstractControl, FormControl } from '@angular/forms';
+import { createAbstractControlSpy, createAbstractControlSpyWithSibling } from '../utils/test.utils';
+import { ArrayValidators } from './array.validators';
+
+let control: jasmine.SpyObj<AbstractControl>;
+
+describe('Array Validators - array', () => {
+    it('Valid for an empty array', () => {
+        control = createAbstractControlSpy([]);
+
+        expect(ArrayValidators.array(control)).toBeNull();
+    });
+
+    it('Valid for a populated array', () => {
+        control = createAbstractControlSpy([1, 2, 3]);
+
+        expect(ArrayValidators.array(control)).toBeNull();
+    });
+
+    it('Invalid for a string', () => {
+        control = createAbstractControlSpy('not an array');
+
+        expect(ArrayValidators.array(control)).toEqual({ array: true });
+    });
+
+    it('Invalid for an object', () => {
+        control = createAbstractControlSpy({ length: 1 });
+
+        expect(ArrayValidators.array(control)).toEqual({ array: true });
+    });
+
+    it('Invalid for null', () => {
+        control = createAbstractControlSpy(null);
+
+        expect(ArrayValidators.array(control)).toEqual({ array: true });
+    });
+});
+
+describe('Array Validators - minSize', () => {
+    it('Valid when length equals the minimum', () => {
+        control = createAbstractControlSpy([1, 2]);
+
+        expect(ArrayValidators.minSize(2)(control)).toBeNull();
+    });
+
+    it('Valid when length exceeds the minimum', () => {
+        control = createAbstractControlSpy([1, 2, 3]);
+
+        expect(ArrayValidators.minSize(2)(control)).toBeNull();
+    });
+
+    it('Invalid when length is below the minimum', () => {
+        control = createAbstractControlSpy([1]);
+
+        expect(ArrayValidators.minSize(2)(control)).toEqual({ minSize: true });
+    });
+
+    it('Invalid for a non-array', () => {
+        control = createAbstractControlSpy('ab');
+
+        expect(ArrayValidators.minSize(1)(control)).toEqual({ minSize: true });
+    });
+});
+
+describe('Array Validators - maxSize', () => {
+    it('Valid when length equals the maximum', () => {
+        control = createAbstractControlSpy([1, 2]);
+
+        expect(ArrayValidators.maxSize(2)(control)).toBeNull();
+    });
+
+    it('Valid when length is below the maximum', () => {
+        control = createAbstractControlSpy([1]);
+
+        expect(ArrayValidators.maxSize(2)(control)).toBeNull();
+    });
+
+    it('Invalid when length exceeds the maximum', () => {
+        control = createAbstractControlSpy([1, 2, 3]);
+
+        expect(ArrayValidators.maxSize(2)(control)).toEqual({ maxSize: true });
+    });
+
+    it('Invalid for a non-array', () => {
+        control = createAbstractControlSpy(null);
+
+        expect(ArrayValidators.maxSize(2)(control)).toEqual({ maxSize: true });
+    });
+});
+
+describe('Array Validators - sizeBetween', () => {
+    it('Valid at the lower bound', () => {
+        control = createAbstractControlSpy([1]);
+
+        expect(ArrayValidators.sizeBetween(1, 3)(control)).toBeNull();
+    });
+
+    it('Valid at the upper bound', () => {
+        control = createAbstractControlSpy([1, 2, 3]);
+
+        expect(ArrayValidators.sizeBetween(1, 3)(control)).toBeNull();
+    });
+
+    it('Invalid below the lower bound', () => {
+        control = createAbstractControlSpy([]);
+
+        expect(ArrayValidators.sizeBetween(1, 3)(control)).toEqual({ sizeBetween: true });
+    });
+
+    it('Invalid above the upper bound', () => {
+        control = createAbstractControlSpy([1, 2, 3, 4]);
+
+        expect(ArrayValidators.sizeBetween(1, 3)(control)).toEqual({ sizeBetween: true });
+    });
+
+    it('Invalid for a non-array', () => {
+        control = createAbstractControlSpy('abc');
+
+        expect(ArrayValidators.sizeBetween(1, 3)(control)).toEqual({ sizeBetween: true });
+    });
+});
+
+describe('Array Validators - distinct', () => {
+    it('Valid for unique primitives', () => {
+        control = createAbstractControlSpy([1, 2, 3]);
+
+        expect(ArrayValidators.distinct(control)).toBeNull();
+    });
+
+    it('Valid for an empty array', () => {
+        control = createAbstractControlSpy([]);
+
+        expect(ArrayValidators.distinct(control)).toBeNull();
+    });
+
+    it('Invalid for duplicate primitives', () => {
+        control = createAbstractControlSpy([1, 2, 2]);
+
+        expect(ArrayValidators.distinct(control)).toEqual({ distinct: true });
+    });
+
+    it('Invalid for duplicate strings', () => {
+        control = createAbstractControlSpy(['a', 'b', 'a']);
+
+        expect(ArrayValidators.distinct(control)).toEqual({ distinct: true });
+    });
+
+    it('Invalid for a non-array', () => {
+        control = createAbstractControlSpy(null);
+
+        expect(ArrayValidators.distinct(control)).toEqual({ distinct: true });
+    });
+});
+
+describe('Array Validators - contains', () => {
+    it('Valid when all required values are present', () => {
+        control = createAbstractControlSpy(['a', 'b', 'c']);
+
+        expect(ArrayValidators.contains('a', 'b')(control)).toBeNull();
+    });
+
+    it('Invalid when a required value is missing', () => {
+        control = createAbstractControlSpy(['a', 'c']);
+
+        expect(ArrayValidators.contains('a', 'b')(control)).toEqual({ contains: true });
+    });
+
+    it('Invalid for a non-array', () => {
+        control = createAbstractControlSpy('ab');
+
+        expect(ArrayValidators.contains('a')(control)).toEqual({ contains: true });
+    });
+});
+
+describe('Array Validators - doesntContain', () => {
+    it('Valid when none of the forbidden values are present', () => {
+        control = createAbstractControlSpy(['a', 'b']);
+
+        expect(ArrayValidators.doesntContain('x', 'y')(control)).toBeNull();
+    });
+
+    it('Invalid when a forbidden value is present', () => {
+        control = createAbstractControlSpy(['a', 'x']);
+
+        expect(ArrayValidators.doesntContain('x', 'y')(control)).toEqual({ doesntContain: true });
+    });
+
+    it('Invalid for a non-array', () => {
+        control = createAbstractControlSpy(null);
+
+        expect(ArrayValidators.doesntContain('x')(control)).toEqual({ doesntContain: true });
+    });
+});
+
+describe('Array Validators - inArray', () => {
+    it('Valid when the value is a member of the sibling array', () => {
+        control = createAbstractControlSpyWithSibling('red', ['red', 'green']);
+
+        expect(ArrayValidators.inArray('allowedColors')(control)).toBeNull();
+    });
+
+    it('Invalid when the value is not a member of the sibling array', () => {
+        control = createAbstractControlSpyWithSibling('blue', ['red', 'green']);
+
+        expect(ArrayValidators.inArray('allowedColors')(control)).toEqual({ inArray: true });
+    });
+
+    it('Invalid when the sibling is not an array', () => {
+        control = createAbstractControlSpyWithSibling('red', 'red');
+
+        expect(ArrayValidators.inArray('allowedColors')(control)).toEqual({ inArray: true });
+    });
+
+    it('Valid under loose equality (string vs number)', () => {
+        control = createAbstractControlSpyWithSibling('1', [1, 2]);
+
+        expect(ArrayValidators.inArray('ids', false)(control)).toBeNull();
+    });
+
+    it('Invalid under strict equality (string vs number)', () => {
+        control = createAbstractControlSpyWithSibling('1', [1, 2]);
+
+        expect(ArrayValidators.inArray('ids', true)(control)).toEqual({ inArray: true });
+    });
+});
+
+describe('Array Validators - arrayOf', () => {
+    const isString = (c: AbstractControl) => (typeof c.value === 'string' ? null : { notString: true });
+
+    it('Valid when every item passes the inner validator', () => {
+        control = createAbstractControlSpy(['a', 'b']);
+
+        expect(ArrayValidators.arrayOf(isString)(control)).toBeNull();
+    });
+
+    it('Valid for an empty array', () => {
+        control = createAbstractControlSpy([]);
+
+        expect(ArrayValidators.arrayOf(isString)(control)).toBeNull();
+    });
+
+    it('Invalid when an item fails the inner validator', () => {
+        control = createAbstractControlSpy(['a', 1]);
+
+        expect(ArrayValidators.arrayOf(isString)(control)).toEqual({ arrayOf: true });
+    });
+
+    it('Works with a real nguard validator', () => {
+        control = createAbstractControlSpy([5, 'x']);
+
+        expect(ArrayValidators.arrayOf(c => (typeof c.value === 'number' ? null : { num: true }))(control)).toEqual({
+            arrayOf: true,
+        });
+    });
+
+    it('Invalid for a non-array', () => {
+        control = createAbstractControlSpy('abc');
+
+        expect(ArrayValidators.arrayOf(isString)(control)).toEqual({ arrayOf: true });
+    });
+
+    it('Wraps each item in a FormControl', () => {
+        const seen: unknown[] = [];
+        const spy = (c: AbstractControl) => {
+            seen.push(c.value);
+            return null;
+        };
+        control = createAbstractControlSpy(['a', 'b']);
+
+        ArrayValidators.arrayOf(spy)(control);
+
+        expect(seen).toEqual(['a', 'b']);
+        expect(new FormControl('a')).toBeTruthy();
+    });
+});
+
+describe('Array Validators - requiredArrayKeys', () => {
+    it('Valid when the object has all required keys', () => {
+        control = createAbstractControlSpy({ id: 1, name: 'x' });
+
+        expect(ArrayValidators.requiredArrayKeys('id', 'name')(control)).toBeNull();
+    });
+
+    it('Invalid when a required key is missing', () => {
+        control = createAbstractControlSpy({ id: 1 });
+
+        expect(ArrayValidators.requiredArrayKeys('id', 'name')(control)).toEqual({ requiredArrayKeys: true });
+    });
+
+    it('Invalid for null', () => {
+        control = createAbstractControlSpy(null);
+
+        expect(ArrayValidators.requiredArrayKeys('id')(control)).toEqual({ requiredArrayKeys: true });
+    });
+
+    it('Invalid for a primitive', () => {
+        control = createAbstractControlSpy('id');
+
+        expect(ArrayValidators.requiredArrayKeys('id')(control)).toEqual({ requiredArrayKeys: true });
+    });
+});

--- a/src/lib/validators/array.validators.ts
+++ b/src/lib/validators/array.validators.ts
@@ -1,0 +1,227 @@
+import { AbstractControl, FormControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { equalityCheck, primitive } from '../utils/validators.utils';
+
+export namespace ArrayValidators {
+    /**
+     * Validate that the value is a JavaScript array.
+     *
+     * ```
+     * new FormControl([], [NguardValidators.Array.array])
+     * ```
+     *
+     * @returns {ValidationErrors | null}
+     */
+    export const array: ValidatorFn = (c: AbstractControl): ValidationErrors | null => {
+        return Array.isArray(c.value) ? null : { array: true };
+    };
+
+    /**
+     * Validate that every item in the array passes the supplied validator. Each item is wrapped
+     * in a transient FormControl before being handed to the validator, so only self-contained
+     * (non cross-field) item validators are supported. A non-array value fails.
+     *
+     * ```
+     * new FormControl(['a@b.com'], [
+     *   NguardValidators.Array.arrayOf(NguardValidators.String.email)
+     * ])
+     * ```
+     *
+     * @param {ValidatorFn} validator The validator applied to each item
+     * @returns {ValidatorFn}
+     */
+    export const arrayOf = (validator: ValidatorFn): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            if (!Array.isArray(c.value)) {
+                return { arrayOf: true };
+            }
+
+            const allValid = c.value.every((item: unknown) => validator(new FormControl(item)) === null);
+
+            return allValid ? null : { arrayOf: true };
+        };
+    };
+
+    /**
+     * Validate that the array contains every one of the given values (membership via Array.includes).
+     * A non-array value fails.
+     *
+     * ```
+     * new FormControl(['a', 'b'], [NguardValidators.Array.contains('a', 'b')])
+     * ```
+     *
+     * @param {...primitive} values The values that must all be present
+     * @returns {ValidatorFn}
+     */
+    export const contains = (...values: primitive[]): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            if (!Array.isArray(c.value)) {
+                return { contains: true };
+            }
+
+            const containsAll = values.every((value: primitive) => c.value.includes(value));
+
+            return containsAll ? null : { contains: true };
+        };
+    };
+
+    /**
+     * Validate that the array has no duplicate values. Uniqueness is determined with Set
+     * value-equality, so primitives are compared by value and objects by reference.
+     * A non-array value fails.
+     *
+     * ```
+     * new FormControl([1, 2, 3], [NguardValidators.Array.distinct])
+     * ```
+     *
+     * @returns {ValidationErrors | null}
+     */
+    export const distinct: ValidatorFn = (c: AbstractControl): ValidationErrors | null => {
+        if (!Array.isArray(c.value)) {
+            return { distinct: true };
+        }
+
+        return new Set(c.value).size === c.value.length ? null : { distinct: true };
+    };
+
+    /**
+     * Validate that the array contains none of the given values (membership via Array.includes).
+     * A non-array value fails.
+     *
+     * ```
+     * new FormControl(['a'], [NguardValidators.Array.doesntContain('x', 'y')])
+     * ```
+     *
+     * @param {...primitive} values The values that must all be absent
+     * @returns {ValidatorFn}
+     */
+    export const doesntContain = (...values: primitive[]): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            if (!Array.isArray(c.value)) {
+                return { doesntContain: true };
+            }
+
+            const containsNone = values.every((value: primitive) => !c.value.includes(value));
+
+            return containsNone ? null : { doesntContain: true };
+        };
+    };
+
+    /**
+     * Validate that the value is a member of a sibling field's array. Fails when the sibling is
+     * missing or is not an array.
+     *
+     * ```
+     * new FormGroup({
+     *   allowedColors: new FormControl(['red', 'green']),
+     *   color: new FormControl('red', [NguardValidators.Array.inArray('allowedColors')]),
+     * })
+     * ```
+     *
+     * @param {string} fieldKey The key of the sibling field holding the array
+     * @param {boolean} [isStrict] If true, membership uses strict equality (===); loose (==) otherwise
+     * @returns {ValidatorFn}
+     */
+    export const inArray = (fieldKey: string, isStrict: boolean = true): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            const sibling = c.parent?.get(fieldKey)?.value;
+
+            if (!Array.isArray(sibling)) {
+                return { inArray: true };
+            }
+
+            const isMember = sibling.some((item: unknown) => equalityCheck(item, c.value, isStrict));
+
+            return isMember ? null : { inArray: true };
+        };
+    };
+
+    /**
+     * Validate that the array has at most `max` items. A non-array value fails.
+     *
+     * ```
+     * new FormControl([1, 2], [NguardValidators.Array.maxSize(3)])
+     * ```
+     *
+     * @param {number} max The maximum number of items (inclusive)
+     * @returns {ValidatorFn}
+     */
+    export const maxSize = (max: number): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            if (!Array.isArray(c.value)) {
+                return { maxSize: true };
+            }
+
+            return c.value.length <= max ? null : { maxSize: true };
+        };
+    };
+
+    /**
+     * Validate that the array has at least `min` items. A non-array value fails.
+     *
+     * ```
+     * new FormControl([1, 2], [NguardValidators.Array.minSize(1)])
+     * ```
+     *
+     * @param {number} min The minimum number of items (inclusive)
+     * @returns {ValidatorFn}
+     */
+    export const minSize = (min: number): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            if (!Array.isArray(c.value)) {
+                return { minSize: true };
+            }
+
+            return c.value.length >= min ? null : { minSize: true };
+        };
+    };
+
+    /**
+     * Validate that the value is a non-null object containing every one of the given keys.
+     * Maps Laravel's `required_array_keys` rule to a plain object.
+     *
+     * ```
+     * new FormControl({ id: 1, name: 'x' }, [
+     *   NguardValidators.Array.requiredArrayKeys('id', 'name')
+     * ])
+     * ```
+     *
+     * @param {...string} keys The keys that must all be present
+     * @returns {ValidatorFn}
+     */
+    export const requiredArrayKeys = (...keys: string[]): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            const value = c.value;
+
+            if (typeof value !== 'object' || value === null) {
+                return { requiredArrayKeys: true };
+            }
+
+            const hasAllKeys = keys.every((key: string) => key in value);
+
+            return hasAllKeys ? null : { requiredArrayKeys: true };
+        };
+    };
+
+    /**
+     * Validate that the array item count is within `[min, max]` inclusive. A non-array value fails.
+     *
+     * ```
+     * new FormControl([1, 2], [NguardValidators.Array.sizeBetween(1, 3)])
+     * ```
+     *
+     * @param {number} min The minimum number of items (inclusive)
+     * @param {number} max The maximum number of items (inclusive)
+     * @returns {ValidatorFn}
+     */
+    export const sizeBetween = (min: number, max: number): ValidatorFn => {
+        return (c: AbstractControl): ValidationErrors | null => {
+            if (!Array.isArray(c.value)) {
+                return { sizeBetween: true };
+            }
+
+            const length = c.value.length;
+
+            return length >= min && length <= max ? null : { sizeBetween: true };
+        };
+    };
+}

--- a/src/lib/validators/nguard.validators.ts
+++ b/src/lib/validators/nguard.validators.ts
@@ -1,9 +1,11 @@
+import { ArrayValidators } from './array.validators';
 import { BooleanValidators } from './boolean.validators';
 import { CrossFieldValidators } from './cross-field.validators';
 import { NumberValidators } from './number.validators';
 import { StringValidators } from './string.validators';
 
 export namespace NguardValidators {
+    export const Array = ArrayValidators;
     export const Boolean = BooleanValidators;
     export const CrossField = CrossFieldValidators;
     export const Number = NumberValidators;

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -11,6 +11,17 @@ export * from './lib/types/field-condition-config.type';
 export type { primitive } from './lib/utils/validators.utils';
 
 // Directives
+// - array
+export * from './lib/directives/array/nguard-array.directive';
+export * from './lib/directives/array/nguard-array-contains.directive';
+export * from './lib/directives/array/nguard-array-doesnt-contain.directive';
+export * from './lib/directives/array/nguard-array-of.directive';
+export * from './lib/directives/array/nguard-distinct.directive';
+export * from './lib/directives/array/nguard-in-array.directive';
+export * from './lib/directives/array/nguard-max-size.directive';
+export * from './lib/directives/array/nguard-min-size.directive';
+export * from './lib/directives/array/nguard-required-array-keys.directive';
+export * from './lib/directives/array/nguard-size-between.directive';
 // - boolean
 export * from './lib/directives/boolean/nguard-accepted.directive';
 export * from './lib/directives/boolean/nguard-accepted-if.directive';


### PR DESCRIPTION
## v0.7.0 — Arrays & Collections

Implements the new `NguardValidators.Array` namespace (issue #52).

### Validators (10)
`array`, `minSize`, `maxSize`, `sizeBetween`, `distinct`, `inArray`, `contains`, `doesntContain`, `arrayOf`, `requiredArrayKeys` — each with a matching signal-based directive (validator/directive parity), validator + directive specs, a docs page, sidebar entry and public-api export.

### Notes
- `contains`/`doesntContain` use the `nguardArrayContains`/`nguardArrayDoesntContain` selectors to avoid clashing with the existing `String` directives.
- Non-array values fail uniformly; compose with an optional rule if empty should pass.
- `distinct` uses `Set` value-equality (primitives by value, objects by reference).
- `inArray` reads a sibling field's array (lives in `Array` per the by-data-type rule).

### Release
- Version bumped `0.6.0 → 0.7.0`, CHANGELOG `[0.7.0]` entry added, v0.7.0 ROADMAP tasks checked off, docs version selector relabeled to `0.7.0`.

### Verification
- `943` unit tests passing (Karma/Firefox headless).
- Docusaurus production build clean.

Closes #52.
